### PR TITLE
feat: add customizable build access key UI with paste/restore

### DIFF
--- a/app/src/main/java/com/tgc/sky/BuildConfig.java
+++ b/app/src/main/java/com/tgc/sky/BuildConfig.java
@@ -6,7 +6,7 @@ public class BuildConfig {
     public static String SKY_STAGE_NAME = "Live";
     public static String SKY_SERVER_HOSTNAME = "live.radiance.thatgamecompany.com";
     public static String SKY_VERSION = "0.17.5";
-    public static final String SKY_BUILD_ACCESS_KEY = "1743442606-0c9545db24db0fee924a028c500c75f968145e6f15d2535ff2ca414798eba96a";
+    public static String SKY_BUILD_ACCESS_KEY = "1743442606-0c9545db24db0fee924a028c500c75f968145e6f15d2535ff2ca414798eba96a";
 
     public static int VERSION_CODE = 192395;
 }

--- a/app/src/main/java/git/artdeell/skymodloader/MainActivity.java
+++ b/app/src/main/java/git/artdeell/skymodloader/MainActivity.java
@@ -35,6 +35,7 @@ import git.artdeell.skymodloader.elfmod.ElfRefcountLoader;
 import git.artdeell.skymodloader.iconloader.IconLoader;
 
 public class MainActivity extends Activity {
+    private static final String DEFAULT_BUILD_KEY = com.tgc.sky.BuildConfig.SKY_BUILD_ACCESS_KEY;
     private SharedPreferences sharedPreferences;
     private boolean ceserverEnabled;
     private boolean hideCanvasMenu;
@@ -153,6 +154,16 @@ public class MainActivity extends Activity {
                 BuildConfig.SKY_SERVER_HOSTNAME = sharedPreferences.getString("server_host",
                         BuildConfig.SKY_SERVER_HOSTNAME);
                 MainActivity.customServer(BuildConfig.SKY_SERVER_HOSTNAME);
+            }
+
+            // Custom build access key override
+            if (sharedPreferences.getBoolean("custom_build_key", false)) {
+                String customKey = sharedPreferences.getString("build_access_key", "");
+                if (customKey != null && !customKey.trim().isEmpty()) {
+                    BuildConfig.SKY_BUILD_ACCESS_KEY = customKey;
+                } else {
+                    BuildConfig.SKY_BUILD_ACCESS_KEY = DEFAULT_BUILD_KEY;
+                }
             }
 
             new ElfRefcountLoader(libPath + ":/system/lib64", modsDir).load();
@@ -277,7 +288,7 @@ public class MainActivity extends Activity {
 
         // Only show the toast for versions below API level 33 (Android 13)
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-            Toast.makeText(this, "Stack trace copied to clipboard", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, getString(R.string.stack_trace_copied), Toast.LENGTH_SHORT).show();
         }
     }
 

--- a/app/src/main/java/git/artdeell/skymodloader/elfmod/ModManagerActivity.java
+++ b/app/src/main/java/git/artdeell/skymodloader/elfmod/ModManagerActivity.java
@@ -3,6 +3,8 @@ package git.artdeell.skymodloader.elfmod;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -13,6 +15,7 @@ import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -44,6 +47,7 @@ import git.artdeell.skymodloader.updater.ModUpdaterService;
 import git.artdeell.skymodloader.updater.VersionNumber;
 
 public class ModManagerActivity extends Activity implements LoadingListener, ModUpdater {
+    private static final String DEFAULT_BUILD_KEY = com.tgc.sky.BuildConfig.SKY_BUILD_ACCESS_KEY;
     private static final int REQUEST_MOD = 1024 * 121;
     @SuppressLint("StaticFieldLeak")
     private static ElfUIBackbone loader;
@@ -205,9 +209,15 @@ public class ModManagerActivity extends Activity implements LoadingListener, Mod
     }
 
     public void setServerUrl(String url) {
-
         sharedPreferences.edit().putString("server_host", url).apply();
+    }
 
+    public void setCustomBuildKey(boolean flag) {
+        sharedPreferences.edit().putBoolean("custom_build_key", flag).apply();
+    }
+
+    public void setBuildAccessKey(String key) {
+        sharedPreferences.edit().putString("build_access_key", key).apply();
     }
 
     public void onAddMod(View v) {
@@ -389,6 +399,8 @@ public class ModManagerActivity extends Activity implements LoadingListener, Mod
         SwitchMaterial enableCeserver = new SwitchMaterial(this);
         SwitchMaterial enableServer = new SwitchMaterial(this);
         TextInputEditText serverSelector = new TextInputEditText(this);
+        SwitchMaterial enableCustomBuildKey = new SwitchMaterial(this);
+        TextInputEditText buildKeyInput = new TextInputEditText(this);
 
 
         LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(
@@ -423,11 +435,15 @@ public class ModManagerActivity extends Activity implements LoadingListener, Mod
         enableServer.setLayoutParams(layoutParams);
         enableServer.setText(R.string.switch_custom_server);
         enableServer.setChecked(sharedPreferences.getBoolean("custom_server", false));
-        enableServer.setOnCheckedChangeListener((buttonView, isChecked) -> setCustomServer(isChecked));
+        enableServer.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            setCustomServer(isChecked);
+            serverSelector.setEnabled(isChecked);
+        });
 
         serverSelector.setText(sharedPreferences.getString("server_host", "insert-url"));
         serverSelector.setSingleLine(true);
         serverSelector.setImeOptions(EditorInfo.IME_ACTION_DONE);
+        serverSelector.setEnabled(enableServer.isChecked());
         serverSelector.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
@@ -440,11 +456,87 @@ public class ModManagerActivity extends Activity implements LoadingListener, Mod
             }
         });
 
+        // Create paste button first so it can be referenced in toggle listener
+        ImageView pasteButton = new ImageView(this);
+        pasteButton.setImageResource(R.drawable.content_paste_24);
+        pasteButton.setPadding(dpToPixels(8), dpToPixels(8), dpToPixels(8), dpToPixels(8));
+        pasteButton.setOnClickListener(v -> {
+            ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+            if (clipboard != null && clipboard.hasPrimaryClip()) {
+                ClipData clip = clipboard.getPrimaryClip();
+                if (clip != null && clip.getItemCount() > 0) {
+                    CharSequence pastedText = clip.getItemAt(0).getText();
+                    if (pastedText != null) {
+                        buildKeyInput.setText(pastedText);
+                        Toast.makeText(this, getString(R.string.pasted_from_clipboard), Toast.LENGTH_SHORT).show();
+                    }
+                }
+            }
+        });
+
+        // Create restore button to reset to default key
+        ImageView restoreButton = new ImageView(this);
+        restoreButton.setImageResource(R.drawable.restore_24);
+        restoreButton.setPadding(dpToPixels(8), dpToPixels(8), dpToPixels(8), dpToPixels(8));
+        restoreButton.setOnClickListener(v -> {
+            buildKeyInput.setText(DEFAULT_BUILD_KEY);
+            Toast.makeText(this, getString(R.string.restored_default_key), Toast.LENGTH_SHORT).show();
+        });
+
+        enableCustomBuildKey.setTextSize(15);
+        enableCustomBuildKey.setLayoutParams(layoutParams);
+        enableCustomBuildKey.setText(R.string.switch_custom_build_key);
+        enableCustomBuildKey.setChecked(sharedPreferences.getBoolean("custom_build_key", false));
+        enableCustomBuildKey.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            setCustomBuildKey(isChecked);
+            buildKeyInput.setEnabled(isChecked);
+            pasteButton.setEnabled(isChecked);
+            pasteButton.setAlpha(isChecked ? 1.0f : 0.4f);
+            restoreButton.setEnabled(isChecked);
+            restoreButton.setAlpha(isChecked ? 1.0f : 0.4f);
+        });
+
+        buildKeyInput.setText(sharedPreferences.getString("build_access_key", DEFAULT_BUILD_KEY));
+        buildKeyInput.setHint(R.string.build_key_hint);
+        buildKeyInput.setSingleLine(true);
+        buildKeyInput.setImeOptions(EditorInfo.IME_ACTION_DONE);
+        buildKeyInput.setEnabled(enableCustomBuildKey.isChecked());
+        pasteButton.setEnabled(enableCustomBuildKey.isChecked());
+        pasteButton.setAlpha(enableCustomBuildKey.isChecked() ? 1.0f : 0.4f);
+        restoreButton.setEnabled(enableCustomBuildKey.isChecked());
+        restoreButton.setAlpha(enableCustomBuildKey.isChecked() ? 1.0f : 0.4f);
+        buildKeyInput.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {}
+            @Override
+            public void afterTextChanged(Editable s) {
+                String key = s.toString();
+                setBuildAccessKey(key);
+            }
+        });
+
+        // Create horizontal layout for build key input + buttons
+        LinearLayout buildKeyRow = new LinearLayout(this);
+        buildKeyRow.setOrientation(LinearLayout.HORIZONTAL);
+        buildKeyRow.setGravity(android.view.Gravity.CENTER_VERTICAL);
+
+        LinearLayout.LayoutParams inputParams = new LinearLayout.LayoutParams(
+                0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f);
+        buildKeyInput.setLayoutParams(inputParams);
+
+        buildKeyRow.addView(buildKeyInput);
+        buildKeyRow.addView(pasteButton);
+        buildKeyRow.addView(restoreButton);
+
         dialogY.container.addView(hideCanvasMenu, layoutParams);
         dialogY.container.addView(bypassUpdate, layoutParams);
         dialogY.container.addView(enableCeserver, layoutParams);
         dialogY.container.addView(enableServer, layoutParams);
         dialogY.container.addView(serverSelector, layoutParams);
+        dialogY.container.addView(enableCustomBuildKey, layoutParams);
+        dialogY.container.addView(buildKeyRow, layoutParams);
         dialogY.dialog.show();
     }
 

--- a/app/src/main/res/drawable/content_paste_24.xml
+++ b/app/src/main/res/drawable/content_paste_24.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="960"
+    android:viewportWidth="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="?colorOnSurface"
+            android:pathData="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h167q11-35 43-57.5t70-22.5q40 0 71.5 22.5T594-840h166q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Zm0-80h560v-560h-80v120H280v-120h-80v560Zm280-560q17 0 28.5-11.5T520-800q0-17-11.5-28.5T480-840q-17 0-28.5 11.5T440-800q0 17 11.5 28.5T480-760Z"/>
+    </group>
+</vector>

--- a/app/src/main/res/drawable/restore_24.xml
+++ b/app/src/main/res/drawable/restore_24.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="960"
+    android:viewportWidth="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="?colorOnSurface"
+            android:pathData="M480-80q-75 0-140.5-28.5t-114-77q-48.5-48.5-77-114T120-440h80q0 117 81.5 198.5T480-160q117 0 198.5-81.5T760-440q0-117-81.5-198.5T480-720h-6l62 62-56 58-160-160 160-160 56 58-62 62h6q75 0 140.5 28.5t114 77q48.5 48.5 77 114T840-440q0 75-28.5 140.5t-77 114q-48.5 48.5-114 77T480-80Z"/>
+    </group>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,11 @@
     <string name="switch_skip_updates">Bypass Game Updates</string>
     <string name="enable_cheat_engine_server">Enable Cheat Engine Server</string>
     <string name="switch_custom_server">Enable Custom Server</string>
+    <string name="switch_custom_build_key">Use custom build access key</string>
+    <string name="build_key_hint">Build access key</string>
+    <string name="pasted_from_clipboard">Pasted from clipboard</string>
+    <string name="restored_default_key">Restored default key</string>
+    <string name="stack_trace_copied">Stack trace copied to clipboard</string>
 
     <string name="close">Close</string>
     <string name="mod_icon">mod icon</string>


### PR DESCRIPTION
### Custom Build Access Key Override

Users will be able to override SKY_BUILD_ACCESS_KEY via Settings UI without needing to rebuild Canvas.

### Behavior

| Toggle | Input     | Result                        |
| ------ | --------- | ----------------------------- |
| OFF    | —         | Uses compiled-in key          |
| ON     | Has value | Uses custom key               |
| ON     | Empty     | Falls back to compiled-in key |

### Tutorial

- **Maintainer:** When TGC rotates its Sky build access key, just publish the new key where users can see it (Discord, GitHub, Telegram).
- **User:** Open Canvas → Settings → Enable toggle → Paste key → Done.
  Instant fix, no rebuild, no waiting for an update.
