### PR TITLE
Added Georgian font support and fixed NDK 29 build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,7 +60,7 @@ android {
         dataBinding = true
         prefab true
     }
-    ndkVersion = '26.1.10909125'
+    ndkVersion = '29.0.14206865'
     namespace 'git.artdeell.skymodloader'
 }
 

--- a/app/src/main/cpp/Utils/artpatch/artpatch.c
+++ b/app/src/main/cpp/Utils/artpatch/artpatch.c
@@ -6,8 +6,12 @@
 #include <string.h>
 #include <android/log.h>
 #include <stdbool.h>
-#include <sys/user.h>
 #include <sys/mman.h>
+#include <unistd.h>
+// PAGE_SIZE was removed from NDK 29 public headers; derive it at runtime.
+#ifndef PAGE_SIZE
+#  define PAGE_SIZE ((size_t)sysconf(_SC_PAGESIZE))
+#endif
 #include "procutils.h"
 
 

--- a/app/src/main/cpp/Utils/imgui_androidbk/androidbk.cpp
+++ b/app/src/main/cpp/Utils/imgui_androidbk/androidbk.cpp
@@ -253,6 +253,34 @@ PRIVATE_API static void loadFonts(ImGuiIO& io, jfloat fontsize, AAssetManager *m
                                  rangesEuropean.Data);
     /* END */
 
+    /* GEORGIAN GLYPH MERGE — merged into the Roboto atlas above.
+     * Roboto does not ship Georgian glyphs; we pull them from whichever
+     * NotoSansGeorgian variant is present on the device (path varies by
+     * Android version and OEM). First successful load wins; missing files
+     * are silently skipped by AddFontFromFileTTF returning nullptr. */
+    {
+        static const ImWchar kGeorgianRanges[] = {
+            0x10A0, 0x10FF, // Georgian (Mkhedruli)
+            0,
+        };
+        static const char* kGeorgianFontCandidates[] = {
+            "/system/fonts/NotoSansGeorgian-VF.ttf",           // OEM / Android 11+ (variable)
+            "/system/fonts/NotoSansGeorgian-Regular.ttf",      // Android <= 11 (static)
+            "/system/fonts/NotoSansGeorgian[wdth,wght].ttf",   // alternative variable naming
+            "/system/fonts/NotoSans-Regular.ttf",               // broad fallback
+            nullptr,
+        };
+        ImFontConfig fcGeo;
+        fcGeo.MergeMode = true;
+        for (int gi = 0; kGeorgianFontCandidates[gi]; ++gi) {
+            if (io.Fonts->AddFontFromFileTTF(kGeorgianFontCandidates[gi], fontsize,
+                                             &fcGeo, kGeorgianRanges)) {
+                break;
+            }
+        }
+    }
+    /* END GEORGIAN */
+
     void* fontBufferDroidSans = nullptr;
 
     /* DROID SANS */


### PR DESCRIPTION
My friend wanted to use the mod in Georgian.
Canvas didn't render the glyphs.
Fixed that, and bumped the NDK while at it.

## Changes
- **Georgian glyphs:** Merge `NotoSansGeorgian` into the ImGui font atlas (`U+10A0-10FF`). Tries multiple font paths so it works across Android versions.
- **NDK 29:** Bump `ndkVersion` to match current SDK.
- **PAGE_SIZE:** Replaced removed `<sys/user.h>` with a `sysconf` define for NDK 29 compat.

## Test
- Clean build, no warnings.
- Runtime verified on OnePlus 13
- Georgian renders correctly in mod UI.

## Screenshot
![CanvasGeorgian-OP13](https://github.com/user-attachments/assets/fd7c192e-ff4d-46f2-b5e6-174013202442)
