### PR TITLE
Fix null-termination and resource leaks in asset loading

### DIFF
--- a/app/src/main/cpp/Core/Cipher/CipherUtils.cpp
+++ b/app/src/main/cpp/Core/Cipher/CipherUtils.cpp
@@ -257,15 +257,17 @@ char* CipherUtils::readAsset(const char* _assetPath) {
     }
 
     size_t asset_size = AAsset_getLength64(aAsset);
-    void* asset_buffer = malloc(asset_size);
-    if (asset_buffer == nullptr) return nullptr; // no mem?
+    void* asset_buffer = malloc(asset_size + 1);
+    if (asset_buffer == nullptr) { AAsset_close(aAsset); return nullptr; }
 
     if (AAsset_read(aAsset, asset_buffer, asset_size) != asset_size) {
         free(asset_buffer);
+        AAsset_close(aAsset);
         return nullptr;
     }
 
     AAsset_close(aAsset);
+    ((char*)asset_buffer)[asset_size] = '\0';
     return (char*)asset_buffer;
 }
 

--- a/app/src/main/cpp/Core/Iconloader/IconLoader.cpp
+++ b/app/src/main/cpp/Core/Iconloader/IconLoader.cpp
@@ -39,7 +39,7 @@ Java_git_artdeell_skymodloader_iconloader_IconLoader_addIcon(
 }
 
 PRIVATE_API SkyImage& die() {
-    SkyImage image;
+    static SkyImage image;
     image.textureId = (ImTextureID)-1;
     return image;
 }
@@ -60,15 +60,15 @@ PRIVATE_API SkyImage& IconLoader::uploadImageKtx(const char* name, const bool& i
 
     size_t assetSz = AAsset_getLength64(aAsset);
     void* assetBuf = malloc(assetSz);
-    if(assetBuf == nullptr) return die();
-    if(AAsset_read(aAsset, assetBuf, assetSz) != assetSz) return die();
+    if(assetBuf == nullptr) { AAsset_close(aAsset); return die(); }
+    if(AAsset_read(aAsset, assetBuf, assetSz) != assetSz) { free(assetBuf); AAsset_close(aAsset); return die(); }
     AAsset_close(aAsset);
     ktxTexture* texture = nullptr;
     GLuint texid = -1;
     GLenum target, error;
-    if(ktxTexture_CreateFromMemory((const ktx_uint8_t *)assetBuf, assetSz, KTX_TEXTURE_CREATE_NO_FLAGS, &texture) != KTX_SUCCESS) return die();
+    if(ktxTexture_CreateFromMemory((const ktx_uint8_t *)assetBuf, assetSz, KTX_TEXTURE_CREATE_NO_FLAGS, &texture) != KTX_SUCCESS) { free(assetBuf); return die(); }
     glGenTextures(1, &texid);
-    if(texid == -1) die();
+    if(texid == -1) { free(assetBuf); ktxTexture_Destroy(texture); return die(); }
     auto *image = new SkyImage;
     error = glGetError();
     while(error != GL_NO_ERROR) {


### PR DESCRIPTION
## Context
Hey I think we hit a crash loop under houdini (ARM-on-x86 emulators) caused by readAsset returning a char* with no null terminator. json::parse calls strlen on it, which walks past the allocation into unmapped memory. On native ARM64, this never surfaces because adjacent heap bytes tend to be zeroed by luck. On houdini the memory layout is different and it faults immediately.

Any mod using read_asset as a C string has the same latent UB.

## Proposed fix
- Let CipherUtils::readAsset() null-terminate the returned buffer (malloc +1, write '\0')
- Fixed AAsset handle leaks on malloc/read failure paths in both readAsset and uploadImageKtx
- Fixed dangling stack reference in IconLoader::die() (local → static)
- Fixed missing buffer/texture cleanup on error paths in uploadImageKtx

## Testing
- [ ] Load a mod that calls Cipher::read_asset() -> verify asset data is intact (no truncation, no corruption)
- [ ] Trigger malloc pressure if possible -> verify no crashes on the error paths (previously leaked AAsset handles)
- [ ] Load custom icons via IconLoader -> verify KTX textures still render correctly
- [ ] Test on both native ARM64 device and houdini emulator (e.g. MuMu) if available

Open to discussion and happy to adjust if needed.