### PR TITLE
Fix Facebook login frozen/unresponsive in WebView

### DIFF
--- a/app/src/main/java/git/artdeell/skymodloader/auth/WebLogin.java
+++ b/app/src/main/java/git/artdeell/skymodloader/auth/WebLogin.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.view.Window;
 import android.view.WindowManager;
+import android.os.Build;
 import android.webkit.CookieManager;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebSettings;
@@ -120,10 +121,15 @@ public class WebLogin extends WebViewClient implements SystemAccountInterface {
         webView.setWebViewClient(this);
         WebSettings settings = webView.getSettings();
         settings.setJavaScriptEnabled(true);
+        settings.setDomStorageEnabled(true);
+        settings.setDatabaseEnabled(true);
+        settings.setUseWideViewPort(true);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            CookieManager.getInstance().setAcceptThirdPartyCookies(webView, true);
+        }
         if(this.accountType == SystemAccountType.kSystemAccountType_Google) {
             settings.setUserAgentString("Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36");
         }
-        //webView.setInitialScale(110);
         webView.loadUrl(loginUrl);
         dialog.show();
         Window dialogWindow = dialog.getWindow();


### PR DESCRIPTION
## Fix Facebook login frozen/unresponsive in WebView

### Problem

The Facebook OAuth page rendered in the WebView but was completely uninteractive. Inputs couldn't be tapped or typed into, the content appeared behind an unskippable barrier. Other providers (Steam, Nintendo) were unaffected.

### Root cause

[WebLogin.java](https://github.com/skyprotocol/Canvas-Open-Source/blob/osp-master/app/src/main/java/git/artdeell/skymodloader/auth/WebLogin.java) was missing several settings that the original Sky OAuth implementation provides. Facebook's login page requires DOM storage, web database support, and third-party cookies to function. Without these, the page paints but its JavaScript cannot operate.

### Fix

Added the missing settings to match the original implementation:

| Setting                    | Purpose                                    |
| -------------------------- | ------------------------------------------ |
| setDomStorageEnabled       | localStorage/sessionStorage for FB scripts |
| setDatabaseEnabled         | Web database support                       |
| setUseWideViewPort         | Proper viewport handling                   |
| setAcceptThirdPartyCookies | Required for cross-domain OAuth flow       |

These are local WebView settings - they don't phone home, add tracking, or include any SDK.

### Before

![Canvas-FB-Login-BEFORE](https://github.com/user-attachments/assets/64bdc785-29ae-4a02-afbb-4b64009bb5d9)

### After

![Canvas-FB-Login-AFTER](https://github.com/user-attachments/assets/6b2f46ed-6a75-4ad0-be53-78ca048c6853)
