### PR TITLE
File picker: multi-MIME and multi-file APIs

### DIFF
--- a/app/src/main/cpp/Core/fileselector/fileselector.cpp
+++ b/app/src/main/cpp/Core/fileselector/fileselector.cpp
@@ -9,12 +9,18 @@
 #include <android/log.h>
 
 jclass class_FileSelector;
+jclass class_String;
 jmethodID method_nselectFile;
+jmethodID method_nselectFileMulti;
+jmethodID method_nselectFiles;
 
 
 PRIVATE_API void fsel_setup(JNIEnv* env) {
     class_FileSelector = (jclass)env->NewGlobalRef(env->FindClass("git/artdeell/skymodloader/FileSelector"));
-    method_nselectFile = env->GetStaticMethodID(class_FileSelector, "nselectFile", "(Ljava/lang/String;JZ)Z");
+    class_String       = (jclass)env->NewGlobalRef(env->FindClass("java/lang/String"));
+    method_nselectFile      = env->GetStaticMethodID(class_FileSelector, "nselectFile",      "(Ljava/lang/String;JZ)Z");
+    method_nselectFileMulti = env->GetStaticMethodID(class_FileSelector, "nselectFileMulti", "([Ljava/lang/String;JZ)Z");
+    method_nselectFiles     = env->GetStaticMethodID(class_FileSelector, "nselectFiles",     "([Ljava/lang/String;J)Z");
 }
 extern "C"
 JNIEXPORT void JNICALL
@@ -24,11 +30,115 @@ Java_git_artdeell_skymodloader_FileSelector_callbackFunctionCall(JNIEnv *env, jc
     callbackFunction(fd);
 }
 
-bool requestFile(const char* mime_type, callback_function callback, bool save) {
-    JNIEnv *env;
-    if(Canvas::javaVM->GetEnv((void**)&env, JNI_VERSION_1_6) == JNI_EDETACHED) {
+extern "C"
+JNIEXPORT void JNICALL
+Java_git_artdeell_skymodloader_FileSelector_multiCallbackFunctionCall(JNIEnv *env, jclass clazz,
+                                                                       jlong cb, jintArray fds) {
+    auto callback = (callback_function_files)cb;
+    if (!fds) {
+        callback(0, nullptr);
+        return;
+    }
+    const jsize n = env->GetArrayLength(fds);
+    if (n == 0) {
+        callback(0, nullptr);
+        return;
+    }
+    jint* native = env->GetIntArrayElements(fds, nullptr);
+    if (!native) {
+        env->ExceptionClear();
+        callback(0, nullptr);
+        return;
+    }
+    callback(static_cast<size_t>(n),
+             reinterpret_cast<const int*>(native));
+    env->ReleaseIntArrayElements(fds, native, JNI_ABORT);
+}
+
+// Log + clear any pending Java exception; otherwise the next JNI call aborts.
+static bool fsel_check_exception(JNIEnv* env, const char* where) {
+    if (env->ExceptionCheck()) {
+        __android_log_print(ANDROID_LOG_ERROR, "fileselector",
+                            "JNI exception pending after %s; clearing", where);
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return true;
+    }
+    return false;
+}
+
+// Returns null on failure; any pending exception is already cleared.
+static jobjectArray fsel_build_mime_array(JNIEnv* env,
+                                          const char* const* mime_types,
+                                          size_t count) {
+    jobjectArray arr = env->NewObjectArray(
+        static_cast<jsize>(count), class_String, nullptr);
+    if (!arr || fsel_check_exception(env, "NewObjectArray")) return nullptr;
+
+    for (size_t i = 0; i < count; ++i) {
+        jstring s = env->NewStringUTF(mime_types[i]);
+        if (!s || fsel_check_exception(env, "NewStringUTF")) {
+            env->DeleteLocalRef(arr);
+            return nullptr;
+        }
+        env->SetObjectArrayElement(arr, static_cast<jsize>(i), s);
+        env->DeleteLocalRef(s);
+        if (fsel_check_exception(env, "SetObjectArrayElement")) {
+            env->DeleteLocalRef(arr);
+            return nullptr;
+        }
+    }
+    return arr;
+}
+
+bool requestFileMulti(const char* const* mime_types, size_t mime_type_count,
+                      callback_function callback, bool save) {
+    if (!mime_types || mime_type_count == 0) return false;
+
+    JNIEnv* env;
+    if (Canvas::javaVM->GetEnv((void**)&env, JNI_VERSION_1_6) == JNI_EDETACHED) {
         __android_log_print(ANDROID_LOG_ERROR, "fileselector", "Not on ImGui UI thread????");
         abort();
     }
-    return env->CallStaticBooleanMethod(class_FileSelector, method_nselectFile, env->NewStringUTF(mime_type), (jlong)callback, save) == JNI_OK;
+
+    jobjectArray mimeArr = fsel_build_mime_array(env, mime_types, mime_type_count);
+    if (!mimeArr) return false;
+
+    jboolean result = env->CallStaticBooleanMethod(
+        class_FileSelector, method_nselectFileMulti,
+        mimeArr, (jlong)callback, save);
+    const bool exceptionRaised = fsel_check_exception(env, "CallStaticBooleanMethod");
+
+    env->DeleteLocalRef(mimeArr);
+
+    if (exceptionRaised) return false;
+    return result == JNI_TRUE;
+}
+
+bool requestFiles(const char* const* mime_types, size_t mime_type_count,
+                  callback_function_files callback) {
+    if (!mime_types || mime_type_count == 0) return false;
+
+    JNIEnv* env;
+    if (Canvas::javaVM->GetEnv((void**)&env, JNI_VERSION_1_6) == JNI_EDETACHED) {
+        __android_log_print(ANDROID_LOG_ERROR, "fileselector", "Not on ImGui UI thread????");
+        abort();
+    }
+
+    jobjectArray mimeArr = fsel_build_mime_array(env, mime_types, mime_type_count);
+    if (!mimeArr) return false;
+
+    jboolean result = env->CallStaticBooleanMethod(
+        class_FileSelector, method_nselectFiles,
+        mimeArr, (jlong)callback);
+    const bool exceptionRaised = fsel_check_exception(env, "CallStaticBooleanMethod");
+
+    env->DeleteLocalRef(mimeArr);
+
+    if (exceptionRaised) return false;
+    return result == JNI_TRUE;
+}
+
+bool requestFile(const char* mime_type, callback_function callback, bool save) {
+    return requestFileMulti(&mime_type, 1, callback, save);
 }

--- a/app/src/main/cpp/Core/fileselector/fileselector.h
+++ b/app/src/main/cpp/Core/fileselector/fileselector.h
@@ -25,4 +25,48 @@ typedef void (*callback_function)(int fd);
  */
 bool requestFile(const char* mime_type, callback_function callback, bool save);
 
+/**
+ * Request a file from the user, accepting any of multiple MIME types.
+ * mime_types - array of MIME type strings (e.g. {"application/json", "text/plain"})
+ * mime_type_count - number of entries; must be > 0
+ * callback - called when a file is selected
+ * save - whether you need to save (true) or load (false)
+ * Returns:
+ * true if the file selection was requested
+ * false if the selector is busy or the input is invalid
+ *
+ * In load mode the picker filters via EXTRA_MIME_TYPES; some OEM pickers
+ * (Huawei, MIUI) ignore the filter, so callers must validate contents.
+ * In save mode only mime_types[0] is honored.
+ */
+bool requestFileMulti(const char* const* mime_types,
+                      size_t mime_type_count,
+                      callback_function callback,
+                      bool save);
+
+/**
+ * Callback for requestFiles.
+ * count - number of file descriptors; 0 on cancel or all-failed
+ * fds - valid only during the callback; callee owns the fds and must close
+ *       them before returning, or copy them out for later use.
+ */
+typedef void (*callback_function_files)(size_t count, const int* fds);
+
+/**
+ * Request one or more files from the user via a multi-select picker.
+ * mime_types - array of MIME type strings; must contain at least one entry
+ * mime_type_count - number of entries; must be > 0
+ * callback - invoked with the selected fds; count == 0 on cancel
+ * Returns:
+ * true if the file selection was requested
+ * false if the selector is busy or the input is invalid
+ *
+ * Picking one file still fires the callback with count == 1.  Some OEM
+ * pickers (Samsung, MIUI) ignore EXTRA_ALLOW_MULTIPLE and EXTRA_MIME_TYPES,
+ * so callers must validate contents.
+ */
+bool requestFiles(const char* const* mime_types,
+                  size_t mime_type_count,
+                  callback_function_files callback);
+
 #endif //SKY_MODLOADER_FILESELECTOR_H

--- a/app/src/main/java/git/artdeell/skymodloader/FileSelector.java
+++ b/app/src/main/java/git/artdeell/skymodloader/FileSelector.java
@@ -1,11 +1,13 @@
 package git.artdeell.skymodloader;
 
 import android.app.Activity;
+import android.content.ClipData;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
 import android.provider.OpenableColumns;
+import android.util.Log;
 
 import com.tgc.sky.GameActivity;
 
@@ -13,6 +15,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -22,6 +27,7 @@ public class FileSelector implements GameActivity.OnActivityResultListener {
     private GameActivity gameActivity;
     private long callbackFunction = 0;
     private boolean isSaveMode;
+    private boolean isMultiFilesMode;
     public static void setActivity(GameActivity activity) {
         activity.AddOnActivityResultListener(selector);
         selector.gameActivity = activity;
@@ -34,39 +40,130 @@ public class FileSelector implements GameActivity.OnActivityResultListener {
         return selector.selectFile(mimeType, callbackFunction, save);
     }
     public boolean selectFile(String mimeType, long callbackFunction, boolean save) {
+        return selectFileMulti(new String[]{ mimeType }, callbackFunction, save);
+    }
+
+    public static boolean nselectFileMulti(String[] mimeTypes, long callbackFunction, boolean save) {
+        return selector.selectFileMulti(mimeTypes, callbackFunction, save);
+    }
+    public boolean selectFileMulti(String[] mimeTypes, long callbackFunction, boolean save) {
         if(this.callbackFunction != 0) return false;
+        if(mimeTypes == null || mimeTypes.length == 0) return false;
+
+        // Copy so caller mutations don't race the UI-thread Intent build.
+        final String[] types = Arrays.copyOf(mimeTypes, mimeTypes.length);
+
+        // ACTION_CREATE_DOCUMENT doesn't support EXTRA_MIME_TYPES; only types[0] is used.
+        if(save && types.length > 1) {
+            Log.w("fileselector",
+                  "save mode received " + types.length
+                  + " MIME types; using first ('" + types[0] + "') only");
+        }
+
         gameActivity.runOnUiThread(()->{
             this.callbackFunction = callbackFunction;
             this.isSaveMode = save;
-            Intent i = new Intent( isSaveMode ? Intent.ACTION_CREATE_DOCUMENT : Intent.ACTION_GET_CONTENT);
-            i.addCategory(Intent.CATEGORY_OPENABLE);
-            i.setType(mimeType);
-            gameActivity.startActivityForResult(i, SELECTING_FILE);
+            this.isMultiFilesMode = false;
+            gameActivity.startActivityForResult(
+                buildPickerIntent(types, save, /*allowMultiple=*/false),
+                SELECTING_FILE);
         });
         return true;
     }
 
+    public static boolean nselectFiles(String[] mimeTypes, long callbackFunction) {
+        return selector.selectFiles(mimeTypes, callbackFunction);
+    }
+    public boolean selectFiles(String[] mimeTypes, long callbackFunction) {
+        if(this.callbackFunction != 0) return false;
+        if(mimeTypes == null || mimeTypes.length == 0) return false;
+
+        final String[] types = Arrays.copyOf(mimeTypes, mimeTypes.length);
+
+        gameActivity.runOnUiThread(()->{
+            this.callbackFunction = callbackFunction;
+            this.isSaveMode = false;
+            this.isMultiFilesMode = true;
+            gameActivity.startActivityForResult(
+                buildPickerIntent(types, /*save=*/false, /*allowMultiple=*/true),
+                SELECTING_FILE);
+        });
+        return true;
+    }
+
+    private static Intent buildPickerIntent(String[] types, boolean save, boolean allowMultiple) {
+        Intent i = new Intent(save ? Intent.ACTION_CREATE_DOCUMENT : Intent.ACTION_GET_CONTENT);
+        i.addCategory(Intent.CATEGORY_OPENABLE);
+        if(allowMultiple) i.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+        if(save || types.length == 1) {
+            i.setType(types[0]);
+        } else {
+            i.setType("*/*");
+            i.putExtra(Intent.EXTRA_MIME_TYPES, types);
+        }
+        return i;
+    }
+
     @Override
     public void onActivityResult(int i, int i2, Intent intent) {
-        if(i == SELECTING_FILE) {
-            int fd = -1;
-            if(i2 == Activity.RESULT_OK) {
-                Uri selectedFile = intent.getData();
-                try {
-                    ParcelFileDescriptor fileDescriptor = gameActivity.getContentResolver().openFileDescriptor(selectedFile, isSaveMode ? "w" : "r");
-                    fd = fileDescriptor.detachFd();
-                    fileDescriptor.close();
-                }catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-            final long fCallbackFunction = callbackFunction;
-            final int fFd = fd;
+        if(i != SELECTING_FILE) return;
+
+        final long fCallbackFunction = callbackFunction;
+        final boolean wasMulti = isMultiFilesMode;
+        callbackFunction = 0;
+        isMultiFilesMode = false;
+
+        if(wasMulti) {
+            final int[] fds = (i2 == Activity.RESULT_OK) ? collectFds(intent) : new int[0];
             new Thread(()->{
-                callbackFunctionCall(fCallbackFunction, fFd);
+                multiCallbackFunctionCall(fCallbackFunction, fds);
             }).start();
-            callbackFunction = 0;
+            return;
         }
+
+        int fd = -1;
+        if(i2 == Activity.RESULT_OK) {
+            Uri selectedFile = intent.getData();
+            try {
+                ParcelFileDescriptor fileDescriptor = gameActivity.getContentResolver().openFileDescriptor(selectedFile, isSaveMode ? "w" : "r");
+                fd = fileDescriptor.detachFd();
+                fileDescriptor.close();
+            }catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        final int fFd = fd;
+        new Thread(()->{
+            callbackFunctionCall(fCallbackFunction, fFd);
+        }).start();
     }
+
+    private int[] collectFds(Intent intent) {
+        List<Uri> uris = new ArrayList<>();
+        ClipData clip = intent.getClipData();
+        if(clip != null) {
+            for(int k = 0; k < clip.getItemCount(); ++k) {
+                uris.add(clip.getItemAt(k).getUri());
+            }
+        } else {
+            Uri single = intent.getData();
+            if(single != null) uris.add(single);
+        }
+
+        List<Integer> opened = new ArrayList<>(uris.size());
+        for(Uri u : uris) {
+            try {
+                ParcelFileDescriptor pfd = gameActivity.getContentResolver().openFileDescriptor(u, "r");
+                opened.add(pfd.detachFd());
+            } catch(Exception e) {
+                e.printStackTrace();
+            }
+        }
+        int[] out = new int[opened.size()];
+        for(int k = 0; k < opened.size(); ++k) out[k] = opened.get(k);
+        return out;
+    }
+
     public static native void callbackFunctionCall(long cb, int fd);
+    public static native void multiCallbackFunctionCall(long cb, int[] fds);
 }


### PR DESCRIPTION
Extends Canvas's file selector with two new entry points and fixes a longstanding return-value inversion bug.

## What was broken

Canvas's current `requestFile` is limited in two ways and broken in one.

**One MIME type per request.** The C entry point accepts a single MIME string. Mods that want to surface files of two related types are stuck. They either filter to one extension, or they show every file on the device. Music sheets are the canonical case. SkyStudio and Specy export `.json`. sky-music.github.io and Tablature Maker emit `.txt` with JSON inside. A user with a `.txt` sheet has to rename it to `.json` before importing, even though the contents were already JSON-compliant. The rename itself isn't always trivial; some phone file managers hide extensions or refuse to change them. The filename is just a sticky note; what's inside is what the mod reads.

**One file per request.** Canvas never set Android's multi-select flag, so the picker forced a single selection even for bulk workflows (importing a whole music album, a translator pushing a revision across all six locale packs in the repo, and so on).

**Return value inverted.** The C side compared the JNI return against the wrong constant, treating it as a status code instead of a boolean. Since the "no error" status happens to be the same value as `false`, every accepted picker was reported as busy and every busy call as accepted. Callers compensated by negating the result.

There was also no JNI exception handling. Pending Java exceptions from string-creation or method-invocation calls could propagate into the next JNI call and abort the process.

## What this PR does

### New entry points

```c
bool requestFileMulti(const char* const* mime_types,
                      size_t mime_type_count,
                      callback_function callback,
                      bool save);

bool requestFiles(const char* const* mime_types,
                  size_t mime_type_count,
                  callback_function_files callback);
```

**`requestFileMulti`** lets a mod hand in a list of acceptable file formats and shows files matching any of them.
**`requestFiles`** turns on the multi-select chip; the callback receives a count and a list of file descriptors, with the callee owning each one.

`requestFile` is preserved verbatim; under the hood it now calls into the new multi-MIME path with a single-element list. One code path, no behavioural change for existing callers besides the inversion fix.

### Fixes

- **Return value inversion corrected.** The picker entry points now return `true` when the picker was accepted, `false` when the selector is already busy.
- **JNI exception state** is now checked, logged, and cleared after every call into Java, via a small helper.

### Plumbing

- The `String` class lookup is now cached once at setup instead of running on every picker call.
- Common helpers extracted on both sides of the JNI bridge; the new entry points and the existing one share their plumbing.
- The caller's MIME list is defensively copied so a caller mutating its array after the call cannot race the UI thread's Intent build.

## What it unlocks

- **Mixed-format music libraries.** Show both extensions in one picker call. No "rename your file" workaround for end users.
- **Batch import.** N files at once instead of N separate picker prompts.
- **Cleaner filtering** for any mod with a small allow-list of formats.

## Backwards compatibility

`requestFile`'s return semantics are corrected. Existing callers that worked around the inversion with `!requestFile(...)` need to drop the `!` after this lands. The function signature, calling convention, and Java method `nselectFile` are unchanged. Affected callers in the wild can grep for `!requestFile` and apply a one line change.

## OEM caveats

AOSP's DocumentsUI honors both the multi-MIME filter and the multi-select flag, but some OEM file pickers (notably Samsung, MIUI, Huawei) silently ignore one or both. The header docs flag this; mods are expected to validate file contents after the callback fires regardless.

## Testing

- Verified `requestFile` single-file flow through the new wrapper (locale pack import, music sheet import via the Tibik mod after a one line `!` fix on the caller side).
- Verified `requestFileMulti` shows `.json` and `.txt` files together on AOSP DocumentsUI.
- `requestFiles` multi-select path needs confirmation on Samsung / MIUI builds to assess `EXTRA_ALLOW_MULTIPLE` honoring before relying on it as a hard guarantee. Falls back to single-file selection gracefully on pickers that ignore the extra.
