### PR TITLE
Cipher: install registry + scan-failure diagnostics

### DIFF
--- a/app/src/main/cpp/Core/Cipher/Cipher.h
+++ b/app/src/main/cpp/Core/Cipher/Cipher.h
@@ -4,6 +4,28 @@
 #include <vector>
 #include <string>
 #include "../../Utils/artpatch/artpatch.h"
+#include <functional>
+
+/**
+ * @brief Cipher install type.
+ */
+enum Types {
+    e_patch,
+    e_hook
+};
+
+/**
+ * @brief Metadata recorded for each successful Fire(). Returned by
+ *        Cipher::DescribePatchesAt et al.
+ */
+struct CipherInstallInfo {
+    std::string    ownerModule;   ///< dladdr basename of caller (e.g. "libtibik.so")
+    std::string    targetLib;     ///< m_libName at install time (target binary)
+    Types          kind;          ///< e_hook | e_patch
+    std::uintptr_t address;       ///< absolute target address
+    std::size_t    bytes;         ///< 16 for hooks (conservative); exact for patches
+    std::uint64_t  installSeq;    ///< monotonic, set at successful Fire()
+};
 
 enum Section {
     BOOTLOADER_ROD = 0,
@@ -133,11 +155,39 @@ public:
      * @return A pointer to a char array containing the asset data.
      */
     static char* read_asset(char* _assetPath);
-};
 
-enum Types {
-    e_patch,
-    e_hook
+    /**
+     * @brief Returns true if any installed hook/patch covers this address.
+     */
+    static bool IsAddressPatched(std::uintptr_t addr);
+
+    /**
+     * @brief Returns every install whose [address, address+bytes) covers
+     *        addr. Sorted by install order.
+     */
+    static std::vector<CipherInstallInfo> DescribePatchesAt(std::uintptr_t addr);
+
+    /**
+     * @brief Returns every install whose byte range overlaps [start, start+len).
+     */
+    static std::vector<CipherInstallInfo> DescribePatchesIn(
+        std::uintptr_t start, std::size_t len);
+
+    /**
+     * @brief When a pattern scan returns 0, list installs that overlap any
+     *        scanned segment of the target library. Two overloads to match
+     *        Cipher::CipherScan / Cipher::CipherScanIdaPattern shapes.
+     */
+    static std::vector<CipherInstallInfo> ExplainScanFailure(
+        const char* bytes, const char* mask, const char* libName = nullptr);
+    static std::vector<CipherInstallInfo> ExplainScanFailure(
+        const std::string& idaPattern, const char* libName = nullptr);
+
+    /**
+     * @brief Subscribe to every successful Fire(). Callback fires outside
+     *        the registry lock; do NOT call Fire()/Restore() from inside.
+     */
+    static void OnInstallEvent(std::function<void(const CipherInstallInfo&)>);
 };
 
 /**
@@ -291,6 +341,7 @@ public:
  */
 class CipherPatch : public CipherBase {
     bool m_fired = false; /**< Flag indicating whether the patch has been applied. */
+    std::size_t m_patchBytes = 0; /**< Byte count from set_Opcode; used by the install registry. */
     patch_t patch; /**< Internal patch structure. */
 
 public:

--- a/app/src/main/cpp/Core/Cipher/Cipher.h
+++ b/app/src/main/cpp/Core/Cipher/Cipher.h
@@ -341,7 +341,6 @@ public:
  */
 class CipherPatch : public CipherBase {
     bool m_fired = false; /**< Flag indicating whether the patch has been applied. */
-    std::size_t m_patchBytes = 0; /**< Byte count from set_Opcode; used by the install registry. */
     patch_t patch; /**< Internal patch structure. */
 
 public:

--- a/app/src/main/cpp/Core/Cipher/CipherHook.cpp
+++ b/app/src/main/cpp/Core/Cipher/CipherHook.cpp
@@ -1,4 +1,5 @@
 #include "Cipher.h"
+#include "CipherRegistry.h"
 
 #include <mutex>
 
@@ -39,6 +40,8 @@ CipherHook* CipherHook::set_Callback(std::uintptr_t _callback) {
 }
 
 CipherHook* CipherHook::Fire() {
+    void* callerPC = __builtin_return_address(0);
+
     //check if fields are set
     const bool invalidHook = this->get_address() == 0 || this->p_Hook == 0;
     const bool invalidCallback = !this->get_Lock() && this->p_Callback == 0;
@@ -53,9 +56,18 @@ CipherHook* CipherHook::Fire() {
         for (auto& instance : CipherBase::s_InstanceVec) {
             CipherHook* pInstance = (CipherHook *)instance;
             if (pInstance->get_address() == this->get_address() && pInstance->get_Lock()) {
+                const auto prior = Cipher::DescribePatchesAt(get_address());
+                LOGW("Cipher: hook at %p rejected - locked by %s",
+                     (void*)get_address(),
+                     prior.empty() ? "<unknown>" : prior.front().ownerModule.c_str());
                 return this;
             } else if (pInstance->get_address() == this->get_address()
                        && pInstance->m_type == Types::e_hook) {
+                const auto prior = Cipher::DescribePatchesAt(get_address());
+                LOGI("Cipher: hook chain at %p - prior=%s, new=%s",
+                     (void*)get_address(),
+                     prior.empty() ? "<unknown>" : prior.front().ownerModule.c_str(),
+                     CipherInternal::ResolveOwnerForLog(callerPC).c_str());
                 this->set_Address(pInstance->p_Hook, false); //hooks the hooked function instead
             }
         }
@@ -82,6 +94,10 @@ CipherHook* CipherHook::Fire() {
     }
 
     CipherBase::s_InstanceVec.push_back((CipherBase *)this);
+    // 16-byte conservative ARM64 prologue size; shadowhook doesn't expose
+    // the exact rewrite count.
+    CipherInternal::RecordInstall(this, callerPC, Types::e_hook,
+                                  this->get_address(), 16, this->get_libName());
     return this;
 }
 
@@ -101,6 +117,7 @@ void CipherHook::m_Restore() {
             (CipherBase *)this
         )
     );
+    CipherInternal::ForgetInstall(this);
 
     // Recursive Restore mutates s_InstanceVec — return after the first match.
     for (auto& instance : CipherBase::s_InstanceVec) {

--- a/app/src/main/cpp/Core/Cipher/CipherHook.cpp
+++ b/app/src/main/cpp/Core/Cipher/CipherHook.cpp
@@ -52,7 +52,7 @@ CipherHook* CipherHook::Fire() {
     if (!this->get_Lock()) {
         for (auto& instance : CipherBase::s_InstanceVec) {
             CipherHook* pInstance = (CipherHook *)instance;
-            if (pInstance->get_Lock()) {
+            if (pInstance->get_address() == this->get_address() && pInstance->get_Lock()) {
                 return this;
             } else if (pInstance->get_address() == this->get_address()
                        && pInstance->m_type == Types::e_hook) {
@@ -78,6 +78,7 @@ CipherHook* CipherHook::Fire() {
         int error_num = shadowhook_get_errno();
         const char *error_msg = shadowhook_to_errmsg(error_num);
         LOGE("hook failed: %d - %s", error_num, error_msg);
+        return this;
     }
 
     CipherBase::s_InstanceVec.push_back((CipherBase *)this);
@@ -101,25 +102,13 @@ void CipherHook::m_Restore() {
         )
     );
 
+    // Recursive Restore mutates s_InstanceVec — return after the first match.
     for (auto& instance : CipherBase::s_InstanceVec) {
         CipherHook* pInstance = (CipherHook *)instance;
         if (pInstance->get_address() == this->p_Hook && pInstance->m_type == Types::e_hook) {
             pInstance->Restore();
             return;
         }
-
-        pInstance->set_Address(this->get_address(), false);
-        shadowhook_unhook(pInstance->stub);
-        pInstance->stub = nullptr;
-
-        CipherBase::s_InstanceVec.erase(
-            std::find(
-                CipherBase::s_InstanceVec.begin(),
-                CipherBase::s_InstanceVec.end(),
-                (CipherBase *)pInstance
-            )
-        );
-        pInstance->Fire();
     }
 }
 

--- a/app/src/main/cpp/Core/Cipher/CipherPatch.cpp
+++ b/app/src/main/cpp/Core/Cipher/CipherPatch.cpp
@@ -17,7 +17,7 @@ CipherPatch* CipherPatch::Fire() {
         return this;
     }
 
-    if (this->get_address() == 0 || this->get_Lock()) {
+    if (this->get_address() == 0) {
         return this;
     }
 

--- a/app/src/main/cpp/Core/Cipher/CipherPatch.cpp
+++ b/app/src/main/cpp/Core/Cipher/CipherPatch.cpp
@@ -10,7 +10,7 @@ PRIVATE_API std::mutex cipher_patch_mtx;
 
 CipherPatch *CipherPatch::set_Opcode(std::string _hex) {
     artpatch_set_hex(this->patch, _hex.c_str());
-    m_patchBytes = _hex.length() / 2;
+    CipherInternal::NotePatchBytes(this, _hex.length() / 2);
     return this;
 }
 
@@ -45,7 +45,9 @@ CipherPatch* CipherPatch::Fire() {
     this->m_fired = true;
 
     CipherInternal::RecordInstall(this, callerPC, Types::e_patch,
-                                  this->get_address(), m_patchBytes, this->get_libName());
+                                  this->get_address(),
+                                  CipherInternal::LookupPatchBytes(this),
+                                  this->get_libName());
     return this;
 }
 

--- a/app/src/main/cpp/Core/Cipher/CipherPatch.cpp
+++ b/app/src/main/cpp/Core/Cipher/CipherPatch.cpp
@@ -1,17 +1,22 @@
 #include "Cipher.h"
+#include "CipherRegistry.h"
 
 #include <mutex>
 
+#include "../include/misc/Logger.h"
 #include "../../include/misc/visibility.h"
 
 PRIVATE_API std::mutex cipher_patch_mtx;
 
 CipherPatch *CipherPatch::set_Opcode(std::string _hex) {
     artpatch_set_hex(this->patch, _hex.c_str());
+    m_patchBytes = _hex.length() / 2;
     return this;
 }
 
 CipherPatch* CipherPatch::Fire() {
+    void* callerPC = __builtin_return_address(0);
+
     if (m_fired) {
         artpatch_apply(this->patch);
         return this;
@@ -26,6 +31,10 @@ CipherPatch* CipherPatch::Fire() {
     for (auto& instance : CipherPatch::s_InstanceVec) {
         CipherPatch* pInstance = (CipherPatch *)instance;
         if (pInstance->get_address() == get_address() && pInstance->get_Lock()) {
+            const auto prior = Cipher::DescribePatchesAt(get_address());
+            LOGW("Cipher: patch at %p rejected - locked by %s",
+                 (void*)get_address(),
+                 prior.empty() ? "<unknown>" : prior.front().ownerModule.c_str());
             return this;
         }
     }
@@ -34,6 +43,9 @@ CipherPatch* CipherPatch::Fire() {
     artpatch_apply(this->patch);
     CipherPatch::s_InstanceVec.push_back((CipherBase *)this);
     this->m_fired = true;
+
+    CipherInternal::RecordInstall(this, callerPC, Types::e_patch,
+                                  this->get_address(), m_patchBytes, this->get_libName());
     return this;
 }
 
@@ -58,5 +70,6 @@ CipherPatch::~CipherPatch() {
             (CipherBase *)this
         )
     );
+    CipherInternal::ForgetInstall(this);
     artpatch_die(this->patch);
 }

--- a/app/src/main/cpp/Core/Cipher/CipherRegistry.cpp
+++ b/app/src/main/cpp/Core/Cipher/CipherRegistry.cpp
@@ -1,0 +1,208 @@
+#include "Cipher.h"
+#include "CipherRegistry.h"
+#include "CipherUtils.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cstring>
+#include <dlfcn.h>
+#include <functional>
+#include <mutex>
+#include <shared_mutex>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <Canvas/Canvas.h>
+#include <KittyMemory/KittyInclude.hpp>
+
+#include "../../include/misc/visibility.h"
+
+namespace {
+
+// Lazy-initialised state. Plain namespace-scope statics race with
+// main.cpp's __attribute__((constructor)) main(), which fires Canvas's
+// own ImGui hook at .so-load time — calling RecordInstall before this
+// TU's dynamic init has run. Function-local statics avoid the race
+// (C++11 guarantees thread-safe lazy init on first call).
+struct RegistryState {
+    std::shared_mutex                                                     mtx;
+    std::unordered_map<CipherBase*, CipherInstallInfo>                    byInstance;
+    std::atomic<std::uint64_t>                                            seq{0};
+    std::vector<std::function<void(const CipherInstallInfo&)>>            listeners;
+};
+
+RegistryState& State() {
+    static RegistryState inst;
+    return inst;
+}
+
+std::string ResolveOwnerImpl(void* callerPC) {
+    if (!callerPC) return "<unknown>";
+    Dl_info info{};
+    if (!dladdr(callerPC, &info) || !info.dli_fname) return "<unknown>";
+    const char* slash = std::strrchr(info.dli_fname, '/');
+    return slash ? slash + 1 : info.dli_fname;
+}
+
+bool SegmentMatches(const KittyMemory::ProcMap& seg, const Flags& f) {
+    switch (f) {
+        case Flags::ReadOnly:        return seg.is_ro;
+        case Flags::ReadAndWrite:    return seg.is_rw;
+        case Flags::ReadAndExecute:  return seg.is_rx;
+        case Flags::Any:             return seg.is_ro || seg.is_rw || seg.is_rx;
+        default:                     return false;
+    }
+}
+
+// Mirrors the segment-derivation in CipherUtils::CipherScan(bytes,mask,flag,…).
+// Returns empty if Canvas::libElfScanner isn't ready yet — i.e. mod fired
+// before the Java settle() callback completed.
+std::vector<std::pair<std::uintptr_t, std::uintptr_t>>
+ResolveScanRanges(const char* libName, const Flags& flag) {
+    std::vector<std::pair<std::uintptr_t, std::uintptr_t>> out;
+    const char* eff = (libName && libName[0]) ? libName : Canvas::libName;
+    if (!eff) return out;
+    const auto scanner = (std::strcmp(eff, Canvas::libName)
+        ? KittyScanner::ElfScanner::createWithPath(eff)
+        : Canvas::libElfScanner);
+    if (!scanner.isValid()) return out;
+    for (const auto& seg : scanner.segments()) {
+        if (SegmentMatches(seg, flag)) {
+            out.emplace_back(seg.startAddress, seg.endAddress);
+        }
+    }
+    return out;
+}
+
+} // anonymous namespace
+
+// ---------------- internal hooks (called from Fire/dtor) -----------------
+
+namespace CipherInternal {
+
+PRIVATE_API void RecordInstall(CipherBase* base, void* callerPC,
+                                Types kind, std::uintptr_t address,
+                                std::size_t bytes, const char* targetLib)
+{
+    CipherInstallInfo info{
+        ResolveOwnerImpl(callerPC),
+        targetLib ? std::string(targetLib) : std::string{},
+        kind,
+        address,
+        bytes,
+        State().seq.fetch_add(1, std::memory_order_relaxed)
+    };
+
+    {
+        std::unique_lock<std::shared_mutex> lock(State().mtx);
+        State().byInstance[base] = info;
+    }
+
+    // Snapshot listeners under shared lock; invoke outside to avoid
+    // re-entrancy deadlocks if a listener queries the registry.
+    std::vector<std::function<void(const CipherInstallInfo&)>> snap;
+    {
+        std::shared_lock<std::shared_mutex> lock(State().mtx);
+        snap = State().listeners;
+    }
+    for (const auto& cb : snap) cb(info);
+}
+
+PRIVATE_API void ForgetInstall(CipherBase* base) {
+    std::unique_lock<std::shared_mutex> lock(State().mtx);
+    State().byInstance.erase(base);
+}
+
+PRIVATE_API std::string ResolveOwnerForLog(void* callerPC) {
+    return ResolveOwnerImpl(callerPC);
+}
+
+} // namespace CipherInternal
+
+// ---------------- public Cipher:: query surface --------------------------
+
+bool Cipher::IsAddressPatched(std::uintptr_t addr) {
+    std::shared_lock<std::shared_mutex> lock(State().mtx);
+    for (const auto& kv : State().byInstance) {
+        const auto& i = kv.second;
+        if (addr >= i.address && addr < i.address + i.bytes) return true;
+    }
+    return false;
+}
+
+std::vector<CipherInstallInfo> Cipher::DescribePatchesAt(std::uintptr_t addr) {
+    std::vector<CipherInstallInfo> out;
+    {
+        std::shared_lock<std::shared_mutex> lock(State().mtx);
+        for (const auto& kv : State().byInstance) {
+            const auto& i = kv.second;
+            if (addr >= i.address && addr < i.address + i.bytes) out.push_back(i);
+        }
+    }
+    std::sort(out.begin(), out.end(),
+              [](const CipherInstallInfo& a, const CipherInstallInfo& b){
+                  return a.installSeq < b.installSeq;
+              });
+    return out;
+}
+
+std::vector<CipherInstallInfo>
+Cipher::DescribePatchesIn(std::uintptr_t start, std::size_t len) {
+    const std::uintptr_t end = start + len;
+    std::vector<CipherInstallInfo> out;
+    {
+        std::shared_lock<std::shared_mutex> lock(State().mtx);
+        for (const auto& kv : State().byInstance) {
+            const auto& i = kv.second;
+            if (i.address < end && (i.address + i.bytes) > start) out.push_back(i);
+        }
+    }
+    std::sort(out.begin(), out.end(),
+              [](const CipherInstallInfo& a, const CipherInstallInfo& b){
+                  return a.installSeq < b.installSeq;
+              });
+    return out;
+}
+
+std::vector<CipherInstallInfo>
+Cipher::ExplainScanFailure(const char* /*bytes*/, const char* mask, const char* libName)
+{
+    if (!mask) return {};
+    const auto ranges = ResolveScanRanges(libName, Flags::Any);
+    if (ranges.empty()) return {};
+
+    std::vector<CipherInstallInfo> hits;
+    {
+        std::shared_lock<std::shared_mutex> lock(State().mtx);
+        for (const auto& kv : State().byInstance) {
+            const auto& i = kv.second;
+            for (const auto& range : ranges) {
+                if (i.address < range.second && (i.address + i.bytes) > range.first) {
+                    hits.push_back(i);
+                    break;
+                }
+            }
+        }
+    }
+    std::sort(hits.begin(), hits.end(),
+              [](const CipherInstallInfo& a, const CipherInstallInfo& b){
+                  return a.installSeq < b.installSeq;
+              });
+    return hits;
+}
+
+std::vector<CipherInstallInfo>
+Cipher::ExplainScanFailure(const std::string& idaPattern, const char* libName)
+{
+    char bytesBuf[256] = {0};
+    std::string maskBuf;
+    CipherUtils::patternToBytes(idaPattern, bytesBuf, maskBuf);
+    return ExplainScanFailure(bytesBuf, maskBuf.c_str(), libName);
+}
+
+void Cipher::OnInstallEvent(std::function<void(const CipherInstallInfo&)> cb) {
+    if (!cb) return;
+    std::unique_lock<std::shared_mutex> lock(State().mtx);
+    State().listeners.push_back(std::move(cb));
+}

--- a/app/src/main/cpp/Core/Cipher/CipherRegistry.cpp
+++ b/app/src/main/cpp/Core/Cipher/CipherRegistry.cpp
@@ -28,6 +28,7 @@ namespace {
 struct RegistryState {
     std::shared_mutex                                                     mtx;
     std::unordered_map<CipherBase*, CipherInstallInfo>                    byInstance;
+    std::unordered_map<CipherBase*, std::size_t>                          patchBytes;
     std::atomic<std::uint64_t>                                            seq{0};
     std::vector<std::function<void(const CipherInstallInfo&)>>            listeners;
 };
@@ -112,6 +113,18 @@ PRIVATE_API void RecordInstall(CipherBase* base, void* callerPC,
 PRIVATE_API void ForgetInstall(CipherBase* base) {
     std::unique_lock<std::shared_mutex> lock(State().mtx);
     State().byInstance.erase(base);
+    State().patchBytes.erase(base);  // no-op for hooks
+}
+
+PRIVATE_API void NotePatchBytes(CipherBase* patch, std::size_t bytes) {
+    std::unique_lock<std::shared_mutex> lock(State().mtx);
+    State().patchBytes[patch] = bytes;
+}
+
+PRIVATE_API std::size_t LookupPatchBytes(CipherBase* patch) {
+    std::shared_lock<std::shared_mutex> lock(State().mtx);
+    auto it = State().patchBytes.find(patch);
+    return it != State().patchBytes.end() ? it->second : 0;
 }
 
 PRIVATE_API std::string ResolveOwnerForLog(void* callerPC) {

--- a/app/src/main/cpp/Core/Cipher/CipherRegistry.h
+++ b/app/src/main/cpp/Core/Cipher/CipherRegistry.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include <string>
+
+#include "Cipher.h"
+
+// Internal helpers consumed by CipherHook::Fire / CipherPatch::Fire and
+// their destructors. Mods include Cipher.h and see the public query
+// surface there; they never need this header.
+namespace CipherInternal {
+    void RecordInstall(CipherBase* base, void* callerPC,
+                       Types kind, std::uintptr_t address,
+                       std::size_t bytes, const char* targetLib);
+    void ForgetInstall(CipherBase* base);
+
+    // Owner-string helper for the in-loop logs.
+    std::string ResolveOwnerForLog(void* callerPC);
+}

--- a/app/src/main/cpp/Core/Cipher/CipherRegistry.h
+++ b/app/src/main/cpp/Core/Cipher/CipherRegistry.h
@@ -15,6 +15,11 @@ namespace CipherInternal {
                        std::size_t bytes, const char* targetLib);
     void ForgetInstall(CipherBase* base);
 
+    // Patch byte count side-table — kept off CipherPatch's class layout to
+    // avoid an ABI bump. set_Opcode records, Fire reads.
+    void NotePatchBytes(CipherBase* patch, std::size_t bytes);
+    std::size_t LookupPatchBytes(CipherBase* patch);
+
     // Owner-string helper for the in-loop logs.
     std::string ResolveOwnerForLog(void* callerPC);
 }


### PR DESCRIPTION
## Summary

Adds a diagnostics layer to Cipher so mods can introspect each other's hooks and patches at runtime. Currently a mod has no way to ask "is this address already claimed, and by whom?", so mods that need to coexist ship hand-curated compatibility tables that drift the moment a peer updates. This PR makes those tables shrinkable.

## Motivation

libtibik's current compatibility table lists libTSM (general-purpose mod, patches tons of things) and libSPT / Sky Packet Tool (network patches). Two entries, both already drifting, and the ecosystem keeps growing. Cipher records nothing about who installed what; chains and rejections happen silently. When `CipherScan` returns 0 because another mod already rewrote the target bytes, the calling mod sees "pattern not found" with no clue why.

## What's added

All on `class Cipher`, all `static` methods. Additive only: no existing API removed, no existing signature changed.

- `IsAddressPatched(addr)`, `DescribePatchesAt(addr)`, `DescribePatchesIn(start, len)` query the registry.
- `ExplainScanFailure(bytes, mask, [libName])` and `ExplainScanFailure(idaPattern, [libName])` list installs that overlap the segments a failed scan would have touched. Turns "pattern not found" into "libSPT.so patched these bytes first".
- `OnInstallEvent(callback)` subscribes to every successful `Fire`.
- `struct CipherInstallInfo` carries owner basename (from `dladdr`), target library, kind (hook or patch), address, byte count, and a monotonic install sequence number.

## YOLO contract

Canvas observes and reports. It does not decide. Each mod author picks back-off, warn-and-proceed, or override. Example:

```cpp
if (Cipher::IsAddressPatched(target)) {
    LOGW("feature X: address claimed by %s; installing anyway",
         Cipher::DescribePatchesAt(target).front().ownerModule.c_str());
}
hook.Fire();  // override at your own risk
```

`set_Lock` semantics are untouched. Mods that want framework-enforced exclusivity keep using it; mods that want YOLO ignore it and consult the registry themselves.

## Implementation notes

- Storage is a side-table inside `libciphered.so`, keyed by `CipherBase*`. Class layouts for `CipherBase` and `CipherHook` are unchanged.
- One ABI bump: `std::size_t m_patchBytes` added to `CipherPatch` so the registry knows the exact byte count for accurate overlap reporting. See "Consumer impact" below; there's a zero-bump alternative if you'd prefer it.
- Identity is captured via `dladdr(__builtin_return_address(0))` inside `Fire`; mods don't register themselves.
- Registry state uses function-local statics to avoid an init-order race with main.cpp's `__attribute__((constructor)) int main()`, which fires Canvas's own ImGui hook at `.so`-load time.
- Chain installs and lock rejections now emit `LOGI` / `LOGW` lines naming both sides; previously silent.

## Consumer impact

**Mods using only `CipherHook`, `CipherScan`, and `CipherUtils`:** zero impact. No header sync, no rebuild, no copy of the new `libciphered.so` required. Existing binaries are unaffected.

**Mods using `CipherPatch`:** need to rebuild against the new `Cipher.h` because the layout grew by one `std::size_t`. An old-build mod that stack-allocates a `CipherPatch` and calls `set_Opcode` on it would have its `patch_t` slot corrupted by the new code writing `m_patchBytes` at the new offset.

**Mods that want to use the new diagnostic APIs:** need both the updated `Cipher.h` and a `libciphered.so` with the new symbols at link time.

**Zero-bump alternative:** if you'd prefer no consumer rebuild at all (including `CipherPatch` users), `m_patchBytes` can move into a second side-table inside `libciphered.so`. About twenty extra lines, fully ABI-clean. Happy to amend.

## Proof of concept

End-to-end test on a real device with libtibik (a CipherUtils consumer) and libSPT (Sky Packet Tool) installed simultaneously. libSPT patches network functions in the game library; libtibik's network init then pattern-scans for `EnqueueRequest` in the same range.

Before this PR:
```
[net] EnqueueRequest pattern not found
[init] network feature unavailable (API calls disabled)
```

After this PR, with libtibik consuming `Cipher::ExplainScanFailure`:
```
[net] EnqueueRequest pattern not found
[net] EnqueueRequest scan overlaps with libSPT.so install at 0x76f42519ac (install seq #1)
[init] network feature unavailable (API calls disabled)
```

The middle line is the registry attributing the failure to a specific other mod by `.so` basename, with the install sequence number proving it was the first non-Canvas install in the process. Everything from `dladdr` identity capture through side-table query through overlap correlation had to work for that line to appear.

## Testing

- Smoke test, Canvas alone, no mods: works.
- libtibik alone: works.
- libtibik + libSPT, the known-conflict combo: diagnostic line above appears as designed.
- Chain detection and lock rejection paths exist but did not fire in the tested combos (the tested mods patch disjoint addresses and nobody uses `set_Lock(true)` today). Both paths have always-on logs if anyone trips them.

## Bundled fixes

A companion commit on the branch fixes four pre-existing latent defects in `CipherHook` / `CipherPatch` (the "random crashes in CipherHook.cpp" TODO from d6a7b81 plus three related). Orthogonal to the registry feature but touches the same files.

## Open questions

1. Zero ABI bump or not (see Consumer impact). Default in this PR keeps the one `std::size_t` bump; happy to refactor to the side-table version.
2. `OnUninstallEvent` is not included. Symmetric to `OnInstallEvent` but no consumer asked yet; easy add later.
