### PR TITLE
Add developer toggle for Starwatch blocking

### DIFF
--- a/app/src/main/cpp/Core/starwatch/starwatch_block.cpp
+++ b/app/src/main/cpp/Core/starwatch/starwatch_block.cpp
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <set>
 #include <mutex>
+#include <atomic>
 #include <android/log.h>
 #include "shadowhook.h"
 #include "../../include/misc/visibility.h"
@@ -26,6 +27,11 @@ static ssize_t (*orig_sendto)(int, const void *, size_t, int,
 
 static std::mutex g_mtx;
 static std::set<int> g_blocked_fds;
+static std::atomic_bool g_starwatch_allowed{false};
+
+PRIVATE_API static bool block_is_enabled() {
+    return !g_starwatch_allowed.load(std::memory_order_relaxed);
+}
 
 PRIVATE_API static bool contains_starwatch(const char *host) {
     if (!host) return false;
@@ -49,7 +55,7 @@ PRIVATE_API static bool is_loopback(const struct sockaddr *addr) {
 PRIVATE_API static int hooked_getaddrinfo(const char *node, const char *service,
                                            const struct addrinfo *hints,
                                            struct addrinfo **res) {
-    if (contains_starwatch(node)) {
+    if (block_is_enabled() && contains_starwatch(node)) {
         __android_log_print(ANDROID_LOG_DEBUG, SW_TAG,
                             "Blocked DNS: %s", node);
 
@@ -74,7 +80,7 @@ PRIVATE_API static int hooked_getaddrinfo(const char *node, const char *service,
 
 PRIVATE_API static int hooked_connect(int fd, const struct sockaddr *addr,
                                        socklen_t addrlen) {
-    if (is_loopback(addr)) {
+    if (block_is_enabled() && is_loopback(addr)) {
         auto *sin = (const struct sockaddr_in *)addr;
         int port = ntohs(sin->sin_port);
         if (port > 1024) {
@@ -91,7 +97,7 @@ PRIVATE_API static int hooked_connect(int fd, const struct sockaddr *addr,
 PRIVATE_API static ssize_t hooked_sendto(int fd, const void *buf, size_t len,
                                           int flags, const struct sockaddr *addr,
                                           socklen_t addrlen) {
-    if (addr && is_loopback(addr)) {
+    if (block_is_enabled() && addr && is_loopback(addr)) {
         auto *sin = (const struct sockaddr_in *)addr;
         int port = ntohs(sin->sin_port);
         if (port > 1024) {
@@ -101,7 +107,7 @@ PRIVATE_API static ssize_t hooked_sendto(int fd, const void *buf, size_t len,
 
     {
         std::lock_guard<std::mutex> lock(g_mtx);
-        if (g_blocked_fds.count(fd)) {
+        if (block_is_enabled() && g_blocked_fds.count(fd)) {
             return (ssize_t)len;
         }
     }
@@ -133,4 +139,14 @@ void starwatch_block_install() {
                         s1 ? "OK" : "FAIL",
                         s2 ? "OK" : "FAIL",
                         s3 ? "OK" : "FAIL");
+}
+
+void starwatch_block_set_allowed(bool allowed) {
+    g_starwatch_allowed.store(allowed, std::memory_order_relaxed);
+    if (allowed) {
+        std::lock_guard<std::mutex> lock(g_mtx);
+        g_blocked_fds.clear();
+    }
+    __android_log_print(ANDROID_LOG_INFO, SW_TAG,
+                        "Starwatch allowed: %s", allowed ? "true" : "false");
 }

--- a/app/src/main/cpp/Core/starwatch/starwatch_block.h
+++ b/app/src/main/cpp/Core/starwatch/starwatch_block.h
@@ -2,5 +2,6 @@
 #define CANVAS_STARWATCH_BLOCK_H
 
 void starwatch_block_install();
+void starwatch_block_set_allowed(bool allowed);
 
 #endif

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -378,3 +378,13 @@ Java_git_artdeell_skymodloader_MainActivity_nativeSetSkyBuildKey(
         LOGI("SkyBuildKey set: %s", g_skyBuildKey.c_str());
     }
 }
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_git_artdeell_skymodloader_MainActivity_nativeSetStarwatchAllowed(
+        JNIEnv *env,
+        jclass clazz,
+        jboolean allowed
+) {
+    starwatch_block_set_allowed(allowed == JNI_TRUE);
+}

--- a/app/src/main/java/git/artdeell/skymodloader/MainActivity.java
+++ b/app/src/main/java/git/artdeell/skymodloader/MainActivity.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import dalvik.system.DexClassLoader;
 import git.artdeell.skymodloader.elfmod.ElfRefcountLoader;
 import git.artdeell.skymodloader.iconloader.IconLoader;
+import git.artdeell.skymodloader.net.StarwatchBlocker;
 
 public class MainActivity extends Activity {
     private SharedPreferences sharedPreferences;
@@ -196,6 +197,8 @@ public class MainActivity extends Activity {
             ElfLoader loader = new ElfLoader(elfLibPath);
             loader.loadLib("libBootloader.so");
             System.loadLibrary("ciphered");
+            nativeSetStarwatchAllowed(sharedPreferences.getBoolean(
+                StarwatchBlocker.PREF_ALLOW_STARWATCH, false));
 
             String buildKey = getSkyBuildAccessKey();
             if (buildKey != null) {
@@ -522,6 +525,7 @@ public class MainActivity extends Activity {
     public static native void lateInitUserLibs();
     public static native void getSysetemUI(Object systemUI);
     private static native void nativeSetSkyBuildKey(String key);
+    private static native void nativeSetStarwatchAllowed(boolean allowed);
 
     public static class DeviceInfo {
         public float xdpi;

--- a/app/src/main/java/git/artdeell/skymodloader/SMLApplication.java
+++ b/app/src/main/java/git/artdeell/skymodloader/SMLApplication.java
@@ -24,6 +24,7 @@ public class SMLApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+        StarwatchBlocker.init(this);
         StarwatchBlocker.install();
         Log.i("Canvas", "SMLApplication.onCreate() called");
         smlApplication = this;

--- a/app/src/main/java/git/artdeell/skymodloader/SettingsActivity.java
+++ b/app/src/main/java/git/artdeell/skymodloader/SettingsActivity.java
@@ -22,12 +22,15 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
+import git.artdeell.skymodloader.net.StarwatchBlocker;
+
 public class SettingsActivity extends AppCompatActivity {
     private static final String TAG = "ClearAppData";
     private static final int REQUEST_PICK_BOOTLOADER = 9001;
     private Switch hideCanvasMenuSwitch;
     private Switch ceserverSwitch;
     private Switch customServerSwitch;
+    private Switch starwatchSwitch;
     private Switch logcatSwitch;
     private EditText serverUrlInput;
 
@@ -40,6 +43,7 @@ public class SettingsActivity extends AppCompatActivity {
         hideCanvasMenuSwitch = findViewById(R.id.mm_hideCanvasMenu);
         ceserverSwitch = findViewById(R.id.mm_enableCeserver);
         customServerSwitch = findViewById(R.id.mm_enableCustomServer);
+        starwatchSwitch = findViewById(R.id.mm_allowStarwatch);
         logcatSwitch = findViewById(R.id.mm_enableLogcat);
         serverUrlInput = findViewById(R.id.server_url_input);
 
@@ -65,6 +69,14 @@ public class SettingsActivity extends AppCompatActivity {
             getSharedPreferences("package_configs", MODE_PRIVATE)
                 .edit().putBoolean("custom_server", isChecked).apply()
         );
+
+        starwatchSwitch.setChecked(getSharedPreferences(StarwatchBlocker.PREFS_NAME, MODE_PRIVATE)
+            .getBoolean(StarwatchBlocker.PREF_ALLOW_STARWATCH, false));
+        starwatchSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            getSharedPreferences(StarwatchBlocker.PREFS_NAME, MODE_PRIVATE)
+                .edit().putBoolean(StarwatchBlocker.PREF_ALLOW_STARWATCH, isChecked).apply();
+            StarwatchBlocker.setStarwatchAllowed(isChecked);
+        });
 
         serverUrlInput.setText(getSharedPreferences("package_configs", MODE_PRIVATE)
             .getString("server_host", ""));

--- a/app/src/main/java/git/artdeell/skymodloader/net/StarwatchBlocker.java
+++ b/app/src/main/java/git/artdeell/skymodloader/net/StarwatchBlocker.java
@@ -1,5 +1,7 @@
 package git.artdeell.skymodloader.net;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.util.Log;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
@@ -17,17 +19,34 @@ import java.net.URLStreamHandlerFactory;
 import java.security.Permission;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public final class StarwatchBlocker {
 
     private static final String TAG = "StarwatchBlocker";
     private static final String BLOCKED_KEYWORD = "starwatch";
+    public static final String PREFS_NAME = "package_configs";
+    public static final String PREF_ALLOW_STARWATCH = "allow_starwatch";
+
+    private static volatile boolean starwatchAllowed = false;
 
     private StarwatchBlocker() {}
 
+    public static void init(Context context) {
+        SharedPreferences preferences = context.getApplicationContext()
+                .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        setStarwatchAllowed(preferences.getBoolean(PREF_ALLOW_STARWATCH, false));
+    }
+
+    public static void setStarwatchAllowed(boolean allowed) {
+        starwatchAllowed = allowed;
+    }
+
     public static boolean shouldBlock(String urlOrHost) {
-        return urlOrHost != null && urlOrHost.toLowerCase().contains(BLOCKED_KEYWORD);
+        return !starwatchAllowed
+                && urlOrHost != null
+                && urlOrHost.toLowerCase(Locale.ROOT).contains(BLOCKED_KEYWORD);
     }
 
     public static void install() {

--- a/app/src/main/res/layout/setting_layout.xml
+++ b/app/src/main/res/layout/setting_layout.xml
@@ -138,6 +138,30 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:layout_gravity="center_vertical"
+                    android:text="@string/allow_starwatch"
+                    android:textSize="15sp" />
+
+                <Switch
+                    android:id="@+id/mm_allowStarwatch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    tools:ignore="UseSwitchCompatOrMaterialXml" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:background="@drawable/buttons"
+                android:orientation="horizontal"
+                android:padding="14dp">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_gravity="center_vertical"
                     android:text="@string/custom_server"
                     android:textSize="15sp" />
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -93,6 +93,7 @@
     <string name="section_developer_options">Для разработчиков</string>
     <string name="cheat_engine_server">Сервер Cheat Engine</string>
     <string name="custom_server">Свой сервер</string>
+	<string name="allow_starwatch">Разрешить Starwatch</string>
     <string name="server_url">Адрес сервера</string>
     <string name="enable_logcat_monitoring">Мониторинг Logcat</string>
     <string name="section_advanced">Дополнительно</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,7 @@
     <string name="section_developer_options">Developer Options</string>
     <string name="cheat_engine_server">Cheat Engine Server</string>
     <string name="custom_server">Custom server</string>
+    <string name="allow_starwatch">Allow Starwatch</string>
     <string name="server_url">Server URL</string>
     <string name="server_url_hint" translatable="false">insert-url</string>
     <string name="enable_logcat_monitoring">Enable Logcat Monitoring</string>


### PR DESCRIPTION
This adds an Allow Starwatch switch to Developer Options.

Starwatch remains blocked by default, preserving the current behavior. When the switch is enabled, the Java WebView filter and native getaddrinfo/connect/sendto hooks stop blocking Starwatch traffic.

_This makes the Starwatch block configurable without changing the default protection behavior._