### PR TITLE
Fixes clipboard paste in Android ImGui text fields

### DIFF
--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -83,13 +83,22 @@ PRIVATE_API void SystemsTest() {
 
 }
 
-PRIVATE_API static void HelpMarker(const char* desc)
+PRIVATE_API static void HelpMarker(const Canvas::UserLib& userLib)
 {
     ImGui::TextDisabled("(?)");
     if (ImGui::BeginItemTooltip())
     {
         ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-        ImGui::TextWrapped("%s", desc);
+        ImGui::TextWrapped("%s: %s", userLib.Name.c_str(), userLib.Version.c_str());
+        if (!userLib.Author.empty()) {
+            ImGui::TextWrapped("Author: %s", userLib.Author.c_str());
+        }
+
+        if (!userLib.Description.empty()) {
+            ImGui::Separator();
+            ImGui::TextWrapped("%s", userLib.Description.c_str());
+        }
+
         ImGui::PopTextWrapPos();
         ImGui::EndTooltip();
     }
@@ -114,20 +123,6 @@ PRIVATE_API void DrawMods() {
             }
         }
     }
-}
-
-#include <sstream>
-std::string formatUserLibInfo(const Canvas::UserLib& _userLib) {
-    std::ostringstream oss;
-    oss << _userLib.Name << ": " << _userLib.Version << "\\n";
-    if (!_userLib.Author.empty()) {
-        oss << "Author: " << _userLib.Author << "\\n";
-    }
-
-    if (!_userLib.Description.empty()) {
-        oss << "---------\\nDescription:\\n" << _userLib.Description << "\\n";
-    }
-    return oss.str();
 }
 
 PRIVATE_API void Canvas::CanvasMenu() {
@@ -159,7 +154,7 @@ PRIVATE_API void Canvas::CanvasMenu() {
             ImGui::Checkbox(userLib.Name.c_str(), &userLib.UIEnabled);
 
             ImGui::TableSetColumnIndex(1);
-            HelpMarker(formatUserLibInfo(userLib).c_str());
+            HelpMarker(userLib);
 
         }
         ImGui::EndTable();

--- a/app/src/main/java/git/artdeell/skymodloader/ImGUI.java
+++ b/app/src/main/java/git/artdeell/skymodloader/ImGUI.java
@@ -1,7 +1,6 @@
 package git.artdeell.skymodloader;
 
 import android.content.ClipData;
-import android.content.ClipDescription;
 import android.content.ClipboardManager;
 import android.content.res.AssetManager;
 import android.view.Surface;
@@ -24,12 +23,19 @@ public class ImGUI implements SurfaceHolder.Callback{
         clipboard = service;
     }
     public static String getClipboard() {
-        if(clipboard.hasPrimaryClip() && clipboard.getPrimaryClipDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
-            ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
-            CharSequence data = item.getText();
-            if(data != null) return data.toString();
+        if (clipboard == null || !clipboard.hasPrimaryClip()) {
+            return "";
         }
-        return "";
+
+        ClipData clip = clipboard.getPrimaryClip();
+        if (clip == null || clip.getItemCount() == 0) {
+            return "";
+        }
+
+        ClipData.Item item = clip.getItemAt(0);
+        SMLApplication app = SMLApplication.deez();
+        CharSequence data = app != null ? item.coerceToText(app) : item.getText();
+        return data != null ? data.toString() : "";
     }
     public static void setClipboard(String data) {
         clipboard.setPrimaryClip(ClipData.newPlainText("ImGui paste", data));

--- a/app/src/main/java/git/artdeell/skymodloader/ImGUITextInput.java
+++ b/app/src/main/java/git/artdeell/skymodloader/ImGUITextInput.java
@@ -2,12 +2,15 @@ package git.artdeell.skymodloader;
 
 import static android.content.Context.INPUT_METHOD_SERVICE;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.text.Editable;
-import android.text.TextWatcher;
+import android.text.InputType;
+import android.text.Selection;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputConnectionWrapper;
 import android.view.inputmethod.InputMethodManager;
 
 import androidx.annotation.NonNull;
@@ -17,6 +20,19 @@ import androidx.annotation.Nullable;
  * This class is intended for sending characters used in chat via the virtual keyboard
  */
 public class ImGUITextInput extends androidx.appcompat.widget.AppCompatEditText {
+    private static final String TEXT_FILLER = "\u2800";
+    private static final int INPUT_TYPE_WITHOUT_AUTOCORRECT = InputType.TYPE_CLASS_TEXT
+            | InputType.TYPE_TEXT_FLAG_MULTI_LINE
+            | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+            | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
+    private static final int INPUT_TYPE_WITH_AUTOCORRECT = InputType.TYPE_CLASS_TEXT
+            | InputType.TYPE_TEXT_FLAG_MULTI_LINE
+            | InputType.TYPE_TEXT_FLAG_AUTO_CORRECT
+            | InputType.TYPE_TEXT_VARIATION_SHORT_MESSAGE;
+
+    /** To disable keyboard autocorrect, change this assignment to INPUT_TYPE_WITHOUT_AUTOCORRECT. */
+    private static final int INPUT_TYPE = INPUT_TYPE_WITH_AUTOCORRECT;
+
     public ImGUITextInput(@NonNull Context context) {
         this(context, null);
     }
@@ -29,8 +45,6 @@ public class ImGUITextInput extends androidx.appcompat.widget.AppCompatEditText 
         setup();
     }
     private final InputMethodManager imm;
-    private boolean mIsDoingInternalChanges = false;
-
 
     /**
      * When we change from app to app, the keyboard gets disabled.
@@ -54,6 +68,90 @@ public class ImGUITextInput extends androidx.appcompat.widget.AppCompatEditText 
         return super.onKeyPreIme(keyCode, event);
     }
 
+    @Override
+    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+        InputConnection inputConnection = super.onCreateInputConnection(outAttrs);
+        outAttrs.inputType = INPUT_TYPE;
+        outAttrs.imeOptions |= EditorInfo.IME_FLAG_NO_EXTRACT_UI
+                | EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING;
+        if (inputConnection == null) {
+            return null;
+        }
+        return new InputConnectionWrapper(inputConnection, false) {
+            @Override
+            public boolean setComposingText(CharSequence text, int newCursorPosition) {
+                String before = getInputText();
+                boolean result = super.setComposingText(text, newCursorPosition);
+                submitTextDiff(before, getInputText());
+                ensureFiller();
+                return result;
+            }
+
+            @Override
+            public boolean commitText(CharSequence text, int newCursorPosition) {
+                String before = getInputText();
+                boolean result = super.commitText(text, newCursorPosition);
+                submitTextDiff(before, getInputText());
+                ensureFiller();
+                return result;
+            }
+
+            @Override
+            public boolean deleteSurroundingText(int beforeLength, int afterLength) {
+                return deleteTextAroundCursor(
+                        () -> super.deleteSurroundingText(beforeLength, afterLength),
+                        beforeLength,
+                        afterLength
+                );
+            }
+
+            @Override
+            public boolean deleteSurroundingTextInCodePoints(int beforeLength, int afterLength) {
+                return deleteTextAroundCursor(
+                        () -> super.deleteSurroundingTextInCodePoints(beforeLength, afterLength),
+                        beforeLength,
+                        afterLength
+                );
+            }
+
+            @Override
+            public boolean sendKeyEvent(KeyEvent event) {
+                String before = getInputText();
+                boolean result = super.sendKeyEvent(event);
+                String after = getInputText();
+
+                if (!before.equals(after)) {
+                    submitTextDiff(before, after);
+                    ensureFiller();
+                    return result;
+                }
+
+                if (event.getAction() == KeyEvent.ACTION_DOWN) {
+                    if (event.getKeyCode() == KeyEvent.KEYCODE_DEL) {
+                        submitBackspace(1);
+                        ensureFiller();
+                        return true;
+                    }
+                    if (event.getKeyCode() == KeyEvent.KEYCODE_ENTER) {
+                        sendEnter();
+                        return true;
+                    }
+
+                    int unicodeChar = event.getUnicodeChar();
+                    if (unicodeChar > 0) {
+                        String text = Character.toString((char) unicodeChar);
+                        submitText(text, 0);
+                        appendInputText(text);
+                        return true;
+                    }
+                }
+
+                ensureFiller();
+                return result;
+            }
+        };
+    }
+
     /**
      * Set the soft keyboard state
      * @param state the state (true=visible)
@@ -63,7 +161,7 @@ public class ImGUITextInput extends androidx.appcompat.widget.AppCompatEditText 
             enable();
             requestFocus();
             imm.showSoftInput(this, InputMethodManager.SHOW_FORCED);
-        }else  {
+        } else {
             imm.hideSoftInputFromWindow(getWindowToken(), 0);
             clear();
             disable();
@@ -75,14 +173,89 @@ public class ImGUITextInput extends androidx.appcompat.widget.AppCompatEditText 
      * Clear the EditText from any leftover inputs
      * It does not affect the in-game input
      */
-    @SuppressLint("SetTextI18n")
     public void clear(){
-        mIsDoingInternalChanges = true;
-        //Braille space, doesn't trigger keyboard auto-complete
-        //replacing directly the text without though setText avoids notifying changes
-        setText("                              ");
-        setSelection(getText().length());
-        mIsDoingInternalChanges = false;
+        Editable editable = getEditableText();
+        editable.clear();
+        editable.append(TEXT_FILLER);
+        Selection.setSelection(editable, editable.length());
+    }
+
+    private String withoutFiller(CharSequence text) {
+        StringBuilder builder = new StringBuilder(text.length());
+        char filler = TEXT_FILLER.charAt(0);
+        for (int i = 0; i < text.length(); ++i) {
+            char ch = text.charAt(i);
+            if (ch != filler) {
+                builder.append(ch);
+            }
+        }
+        return builder.toString();
+    }
+
+    private String getInputText() {
+        return withoutFiller(getEditableText());
+    }
+
+    private void ensureFiller() {
+        Editable editable = getEditableText();
+        if (editable.length() == 0) {
+            editable.append(TEXT_FILLER);
+        }
+        Selection.setSelection(editable, editable.length());
+    }
+
+    private void submitText(String text, int start) {
+        for (int i = start; i < text.length(); ++i) {
+            ImGUI.submitUnicodeEvent(text.charAt(i));
+        }
+    }
+
+    private void submitBackspace(int count) {
+        for (int i = 0; i < count; ++i) {
+            ImGUI.submitKeyEvent(KeyEvent.KEYCODE_DEL, true);
+            ImGUI.submitKeyEvent(KeyEvent.KEYCODE_DEL, false);
+        }
+    }
+
+    private void submitTextDiff(String oldText, String newText) {
+        if (oldText.equals(newText)) {
+            return;
+        }
+
+        int commonPrefix = 0;
+        int maxCommonPrefix = Math.min(oldText.length(), newText.length());
+        while (commonPrefix < maxCommonPrefix
+                && oldText.charAt(commonPrefix) == newText.charAt(commonPrefix)) {
+            commonPrefix++;
+        }
+
+        submitBackspace(oldText.length() - commonPrefix);
+        submitText(newText, commonPrefix);
+    }
+
+    private void appendInputText(String text) {
+        Editable editable = getEditableText();
+        editable.append(text);
+        Selection.setSelection(editable, editable.length());
+    }
+
+    private boolean deleteTextAroundCursor(InputConnectionAction action, int beforeLength, int afterLength) {
+        String before = getInputText();
+        boolean result = action.run();
+        String after = getInputText();
+
+        if (before.equals(after) && beforeLength > 0 && afterLength == 0) {
+            submitBackspace(beforeLength);
+        } else {
+            submitTextDiff(before, after);
+        }
+
+        ensureFiller();
+        return result;
+    }
+
+    private interface InputConnectionAction {
+        boolean run();
     }
 
     /** Regain ability to exist, take focus and have some text being input */
@@ -111,6 +284,8 @@ public class ImGUITextInput extends androidx.appcompat.widget.AppCompatEditText 
 
     /** This function deals with anything that has to be executed when the constructor is called */
     private void setup(){
+        setRawInputType(INPUT_TYPE);
+        setImeOptions(EditorInfo.IME_FLAG_NO_EXTRACT_UI | EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING);
         setOnEditorActionListener((textView, i, keyEvent) -> {
             sendEnter();
             clear();
@@ -119,34 +294,5 @@ public class ImGUITextInput extends androidx.appcompat.widget.AppCompatEditText 
         });
         clear();
         disable();
-        addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-
-            }
-
-            /**
-             * We take the new chars, and send them to the game.
-             * If less chars are present, remove some.
-             * The text is always cleaned up.
-             */
-            @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
-                if(mIsDoingInternalChanges)return;
-                if (count != 0)
-                    ImGUI.submitUnicodeEvent(s.charAt(start + before));
-                else {
-                    ImGUI.submitKeyEvent(KeyEvent.KEYCODE_DEL, true);
-                    ImGUI.submitKeyEvent(KeyEvent.KEYCODE_DEL, false);
-                }
-                //Reset the keyboard state
-                clear();
-            }
-
-            @Override
-            public void afterTextChanged(Editable s) {
-
-            }
-        });
     }
 }


### PR DESCRIPTION
Pasted text is now inserted completely instead of only the first character. Clipboard content is read with ClipData.Item.coerceToText(Context):
https://developer.android.com/reference/android/content/ClipData.Item#coerceToText(android.content.Context)

[The input type is also now configurable in code. Autocorrect is enabled by default, and it can be disabled by switching INPUT_TYPE to INPUT_TYPE_WITHOUT_AUTOCORRECT](https://github.com/skyprotocol/Canvas-Open-Source/compare/osp-master...HinnliDev:Canvas-Open-Source:osp-master?expand=1#diff-8a6aa53ea733681fc3c473978b96b73c04979ffd057900d4a5c5b946a416a0a1R34)

https://github.com/user-attachments/assets/f12f38f0-986f-40a4-966b-5a7cc97303db

