### PR TITLE
Add per-mod offsets import and update support

### DIFF
--- a/app/src/main/java/git/artdeell/skymodloader/elfmod/ElfModMetadata.java
+++ b/app/src/main/java/git/artdeell/skymodloader/elfmod/ElfModMetadata.java
@@ -19,6 +19,7 @@ public class ElfModMetadata {
     public boolean displaysUI;
     public boolean selfManagedUI;
     public String githubReleasesUrl;
+    public String offsetsUrl;
 
     @Override
     public boolean equals(Object o) {
@@ -35,6 +36,14 @@ public class ElfModMetadata {
 
     public String getGithubReleasesUrl() {
         return this.githubReleasesUrl;
+    }
+
+    public String getOffsetsUrl() {
+        return this.offsetsUrl;
+    }
+
+    public boolean hasOffsetsUrl() {
+        return offsetsUrl != null && !offsetsUrl.isEmpty();
     }
 
     public String getName() {

--- a/app/src/main/java/git/artdeell/skymodloader/elfmod/ElfUIBackbone.java
+++ b/app/src/main/java/git/artdeell/skymodloader/elfmod/ElfUIBackbone.java
@@ -149,6 +149,7 @@ public class ElfUIBackbone {
                 defaultMeta.patchVersion = jsonConfig.getInt("patchVersion");
                 defaultMeta.displayName = jsonConfig.optString("displayName");
                 defaultMeta.githubReleasesUrl = jsonConfig.optString("githubReleasesUrl");
+                defaultMeta.offsetsUrl = jsonConfig.optString("offsetsUrl");
                 JSONArray jdeps = jsonConfig.getJSONArray("dependencies");
                 ElfModMetadata[] dependencies = new ElfModMetadata[jdeps.length()];
                 for (int i = 0; i < dependencies.length; i++) {

--- a/app/src/main/java/git/artdeell/skymodloader/elfmod/ModListAdapter.java
+++ b/app/src/main/java/git/artdeell/skymodloader/elfmod/ModListAdapter.java
@@ -66,21 +66,33 @@ public class ModListAdapter extends RecyclerView.Adapter<ModListAdapter.ViewHold
             }
 
             LinearLayout checkForUpdatesLayout = myView.findViewById(R.id.check_for_updates);
+            TextView textUpdate = myView.findViewById(R.id.text_update);
+            ImageView imageUpdate = myView.findViewById(R.id.image_update);
             String githubReleasesRegex = "https://api\\.github\\.com/repos/.+/releases/latest";
+            boolean hasGithubUpdates = metadata.githubReleasesUrl != null && metadata.githubReleasesUrl.matches(githubReleasesRegex);
+            boolean hasOffsetsUpdates = metadata.hasOffsetsUrl();
 
-            if (metadata.githubReleasesUrl != null && metadata.githubReleasesUrl.matches(githubReleasesRegex)) {
+            if (hasGithubUpdates || hasOffsetsUpdates) {
+                checkForUpdatesLayout.setEnabled(true);
                 checkForUpdatesLayout.setVisibility(View.VISIBLE);
+                textUpdate.setText(R.string.check_for_updates);
+                textUpdate.setTextColor(ContextCompat.getColor(myView.getContext(), R.color.text));
+                imageUpdate.clearColorFilter();
             } else {
                 checkForUpdatesLayout.setEnabled(false);
-                TextView textUpdate = myView.findViewById(R.id.text_update);
                 textUpdate.setText(R.string.no_update_links);
                 textUpdate.setTextColor(ContextCompat.getColor(myView.getContext(), android.R.color.darker_gray));
-                ((ImageView)myView.findViewById(R.id.image_update)).setColorFilter(ContextCompat.getColor(myView.getContext(), android.R.color.darker_gray));
+                imageUpdate.setColorFilter(ContextCompat.getColor(myView.getContext(), android.R.color.darker_gray));
             }
 
             myView.findViewById(R.id.check_for_updates).setOnClickListener(v -> {
                 Log.i("AA", "onClick()");
                 onCheckForUpdates(metadata);
+            });
+            myView.findViewById(R.id.import_offsets).setOnClickListener(v -> {
+                if (loader.activity instanceof ModManagerActivity) {
+                    ((ModManagerActivity) loader.activity).showImportOffsetsDialog(metadata);
+                }
             });
             binding.setItem(metadata);
         }

--- a/app/src/main/java/git/artdeell/skymodloader/elfmod/ModManagerActivity.java
+++ b/app/src/main/java/git/artdeell/skymodloader/elfmod/ModManagerActivity.java
@@ -111,6 +111,7 @@ public class ModManagerActivity extends Activity implements LoadingListener, Mod
         }
         Intent serviceStartIntent = new Intent(this, ModUpdaterService.class);
         serviceStartIntent.putExtra(ModUpdaterService.EXTRA_UPDATE_URL, metadata.getGithubReleasesUrl());
+        serviceStartIntent.putExtra(ModUpdaterService.EXTRA_OFFSETS_URL, metadata.getOffsetsUrl());
         serviceStartIntent.putExtra(ModUpdaterService.EXTRA_LIB_NAME, metadata.name);
         serviceStartIntent.putExtra(ModUpdaterService.EXTRA_VERSION_NUMBER,
             new VersionNumber(metadata.majorVersion, metadata.minorVersion, metadata.patchVersion)
@@ -414,12 +415,8 @@ public class ModManagerActivity extends Activity implements LoadingListener, Mod
         startActivity(new Intent(this, SettingsActivity.class));
     }
 
-    public void onImportOffsetsClick(View view) {
-        if (loader == null || loader.getModsCount() == 0) {
-            Toast.makeText(this, R.string.no_mods_installed, Toast.LENGTH_SHORT).show();
-            return;
-        }
-
+    public void showImportOffsetsDialog(ElfModUIMetadata metadata) {
+        if (metadata == null) return;
         Dialog dialog = new Dialog(this);
         dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
         dialog.setContentView(R.layout.dialog_import_offsets);
@@ -435,7 +432,7 @@ public class ModManagerActivity extends Activity implements LoadingListener, Mod
         dialog.findViewById(R.id.dialog_offsets_import)
             .setOnClickListener(v -> {
                 dialog.dismiss();
-                showModSelectorForOffsets();
+                startOffsetImport(metadata);
             });
 
         dialog.findViewById(R.id.dialog_offsets_discord)
@@ -447,6 +444,14 @@ public class ModManagerActivity extends Activity implements LoadingListener, Mod
             .setOnClickListener(v -> dialog.dismiss());
 
         dialog.show();
+    }
+
+    private void startOffsetImport(ElfModUIMetadata metadata) {
+        pendingOffsetsMod = metadata;
+        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+        intent.setType("*/*");
+        intent.putExtra(Intent.EXTRA_MIME_TYPES, new String[]{"application/json", "text/plain"});
+        startActivityForResult(intent, REQUEST_IMPORT_OFFSETS);
     }
 
     private void showModSelectorForOffsets() {

--- a/app/src/main/java/git/artdeell/skymodloader/updater/AbstractUpdaterService.java
+++ b/app/src/main/java/git/artdeell/skymodloader/updater/AbstractUpdaterService.java
@@ -67,7 +67,7 @@ public abstract class AbstractUpdaterService extends Service {
                 return updateChangelog;
             }
             public void downloadUpdate() {
-                new Thread(AbstractUpdaterService.this::downloadUpdate0).start();
+                new Thread(() -> AbstractUpdaterService.this.downloadUpdate0()).start();
             }
             public long getDownloadMaximum() {
                 return mMaximumProgress.get();
@@ -102,7 +102,7 @@ public abstract class AbstractUpdaterService extends Service {
         return START_NOT_STICKY;
     }
 
-    private void downloadUpdate0() {
+    protected void downloadUpdate0() {
         try {
             changeState(SERVICE_STATE_DOWNLOADING);
             HttpURLConnection conn = (HttpURLConnection) new URL(updateURL).openConnection();
@@ -139,12 +139,12 @@ public abstract class AbstractUpdaterService extends Service {
         changeState(SERVICE_STATE_INSTALL_FINISHED);
     }
 
-    private JSONObject pullUpdateInfo() throws IOException, JSONException {
+    protected JSONObject pullUpdateInfo() throws IOException, JSONException {
         // "https://api.github.com/repos/RomanChamelo/Canvas-Open-Source/releases/latest"
         InputStream inputStream = new URL(getUpdateCheckerURL()).openStream();
         return new JSONObject(new BufferedReader(new InputStreamReader(inputStream)).lines().collect(Collectors.joining("\n")));
     }
-    private String getAssetURL(JSONObject release) throws JSONException {
+    protected String getAssetURL(JSONObject release) throws JSONException {
         if(!release.has("assets")) return null;
         JSONArray assets = release.getJSONArray("assets");
         for(int i = 0; i < assets.length(); i++) {
@@ -182,7 +182,7 @@ public abstract class AbstractUpdaterService extends Service {
         }
     }
 
-    private void announceProgressChange() {
+    protected void announceProgressChange() {
         try {
             mUpdaterListener.onProgressBarChanged();
         } catch (RemoteException e) {
@@ -190,7 +190,7 @@ public abstract class AbstractUpdaterService extends Service {
         }
     }
 
-    private void changeState(byte newState) {
+    protected void changeState(byte newState) {
         try {
             serviceState = newState;
             mUpdaterListener.onStateChanged();
@@ -200,7 +200,15 @@ public abstract class AbstractUpdaterService extends Service {
     }
 
     protected final void start() {
-        new Thread(AbstractUpdaterService.this::findUpdates).start();
+        new Thread(this::findUpdates).start();
+    }
+
+    protected final void setDownloadException(Exception exception) {
+        mDownloadException = exception;
+    }
+
+    protected final void setUpdateChangelog(String changelog) {
+        updateChangelog = changelog;
     }
 
     protected final File getDownloadTarget() {

--- a/app/src/main/java/git/artdeell/skymodloader/updater/ModUpdaterService.java
+++ b/app/src/main/java/git/artdeell/skymodloader/updater/ModUpdaterService.java
@@ -5,23 +5,39 @@ import android.os.Bundle;
 import android.util.Log;
 
 import org.json.JSONException;
+import org.json.JSONArray;
 import org.json.JSONObject;
+import org.json.JSONTokener;
 
+import java.io.ByteArrayInputStream;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
+import git.artdeell.skymodloader.R;
 import git.artdeell.skymodloader.elfmod.ElfModMetadata;
 import git.artdeell.skymodloader.elfmod.ElfRefcountLoader;
 
 public class ModUpdaterService extends AbstractUpdaterService {
     public static final String EXTRA_UPDATE_URL = "update_url";
+    public static final String EXTRA_OFFSETS_URL = "offsets_url";
     public static final String EXTRA_LIB_NAME = "lib_name";
     public static final String EXTRA_VERSION_NUMBER = "version_number";
     private String mGithubUpdaterURL;
+    private String mOffsetsURL;
     private File mLibraryPath;
     private VersionNumber mCurrentVersionNumber;
+    private boolean mModUpdateAvailable;
+    private boolean mOffsetsUpdateAvailable;
+    private String mModDownloadURL;
+    private String mPendingOffsetsJson;
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
@@ -31,6 +47,7 @@ public class ModUpdaterService extends AbstractUpdaterService {
             Log.w("ModUpdater","Extras missing for ModUpdater startup");
         }else {
             mGithubUpdaterURL = extras.getString(EXTRA_UPDATE_URL);
+            mOffsetsURL = extras.getString(EXTRA_OFFSETS_URL);
             mCurrentVersionNumber = (VersionNumber) extras.getSerializable(EXTRA_VERSION_NUMBER);
             String libName = extras.getString(EXTRA_LIB_NAME);
             mLibraryPath = new File(getFilesDir(), "mods"+File.separator+libName);
@@ -74,6 +91,89 @@ public class ModUpdaterService extends AbstractUpdaterService {
     }
 
     @Override
+    public void findUpdates() {
+        if(getDownloadTarget().exists()) getDownloadTarget().delete();
+        mModUpdateAvailable = false;
+        mOffsetsUpdateAvailable = false;
+        mModDownloadURL = null;
+        mPendingOffsetsJson = null;
+
+        try {
+            StringBuilder changelog = new StringBuilder();
+            if(hasText(mGithubUpdaterURL)) {
+                JSONObject updateInfo = readJsonObject(mGithubUpdaterURL);
+                String assetURL = getAssetURL(updateInfo);
+                if(assetURL != null && needsUpdate(updateInfo)) {
+                    mModUpdateAvailable = true;
+                    mModDownloadURL = assetURL;
+                    String releaseNotes = updateInfo.optString("body");
+                    if(hasText(releaseNotes)) {
+                        changelog.append(releaseNotes);
+                    }
+                }
+            }
+
+            if(hasText(mOffsetsURL)) {
+                String offsetsJson = readUrl(mOffsetsURL);
+                Object parsedOffsetsJson = parseJson(offsetsJson);
+                String normalizedRemoteOffsets = normalizeJson(parsedOffsetsJson);
+                String normalizedLocalOffsets = readLocalOffsetsJson();
+                if(!normalizedRemoteOffsets.equals(normalizedLocalOffsets)) {
+                    mOffsetsUpdateAvailable = true;
+                    mPendingOffsetsJson = offsetsJson;
+                    if(changelog.length() > 0) {
+                        changelog.append("\n\n");
+                    }
+                    changelog.append(buildOffsetsChangelog(parsedOffsetsJson));
+                }
+            }
+
+            setProgressBarMax(0);
+            if(mModUpdateAvailable || mOffsetsUpdateAvailable) {
+                setUpdateChangelog(changelog.length() > 0 ? changelog.toString() : null);
+                changeState(SERVICE_STATE_UPDATE_AVAILABLE);
+            } else {
+                changeState(SERVICE_STATE_PROCEED);
+            }
+        } catch (Exception e) {
+            setDownloadException(e);
+            setProgressBarMax(0);
+            changeState(SERVICE_STATE_FAILURE);
+        }
+    }
+
+    @Override
+    protected void downloadUpdate0() {
+        try {
+            if(mModUpdateAvailable) {
+                changeState(SERVICE_STATE_DOWNLOADING);
+                downloadToFile(mModDownloadURL, getDownloadTarget());
+                changeState(SERVICE_STATE_INSTALLING);
+                performInstallActions();
+            }
+
+            if(mOffsetsUpdateAvailable) {
+                changeState(SERVICE_STATE_DOWNLOADING);
+                String offsetsJson = mPendingOffsetsJson != null ? mPendingOffsetsJson : readUrl(mOffsetsURL);
+                parseJson(offsetsJson);
+
+                changeState(SERVICE_STATE_INSTALLING);
+                byte[] offsetsBytes = offsetsJson.getBytes(StandardCharsets.UTF_8);
+                setProgressBarMax(offsetsBytes.length);
+                try (ByteArrayInputStream inputStream = new ByteArrayInputStream(offsetsBytes);
+                     FileOutputStream outputStream = new FileOutputStream(getOffsetsFile())) {
+                    copyStream(inputStream, outputStream, true);
+                }
+            }
+
+            changeState(SERVICE_STATE_INSTALL_FINISHED);
+        } catch (Exception e) {
+            setDownloadException(e);
+            changeState(SERVICE_STATE_FAILURE);
+        }
+    }
+
+    @Override
     protected void performInstallActions() throws Exception {
         File source = getDownloadTarget();
         ElfModMetadata metadata = ElfRefcountLoader.loadMetadata(source);
@@ -93,5 +193,171 @@ public class ModUpdaterService extends AbstractUpdaterService {
                 copyStream(inputStream, outputStream, length != -1);
             }
         }
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isEmpty();
+    }
+
+    private JSONObject readJsonObject(String url) throws IOException, JSONException {
+        return new JSONObject(readUrl(url));
+    }
+
+    private String readUrl(String url) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        connection.setConnectTimeout(10000);
+        connection.setReadTimeout(10000);
+        try {
+            int responseCode = connection.getResponseCode();
+            InputStream inputStream = responseCode >= 200 && responseCode < 300
+                ? connection.getInputStream()
+                : connection.getErrorStream();
+            String response = readStream(inputStream);
+            if(responseCode < 200 || responseCode >= 300) {
+                throw new IOException("Request failed: HTTP " + responseCode);
+            }
+            return response;
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private void downloadToFile(String url, File target) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        connection.connect();
+        try (InputStream inputStream = connection.getInputStream();
+             FileOutputStream outputStream = new FileOutputStream(target)) {
+            long totalLength = connection.getContentLength();
+            setProgressBarMax(totalLength);
+            copyStream(inputStream, outputStream, totalLength != -1);
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private String readStream(InputStream inputStream) throws IOException {
+        if(inputStream == null) return "";
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+            StringBuilder builder = new StringBuilder();
+            String line;
+            while((line = reader.readLine()) != null) {
+                builder.append(line).append('\n');
+            }
+            return builder.toString();
+        }
+    }
+
+    private String readLocalOffsetsJson() {
+        File offsetsFile = getOffsetsFile();
+        if(!offsetsFile.exists()) return "";
+        try (FileInputStream inputStream = new FileInputStream(offsetsFile)) {
+            return normalizeJson(parseJson(readStream(inputStream)));
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private Object parseJson(String json) throws JSONException {
+        Object parsedJson = new JSONTokener(json).nextValue();
+        if(parsedJson instanceof JSONObject || parsedJson instanceof JSONArray) {
+            return parsedJson;
+        }
+        throw new JSONException("Offsets URL did not return a JSON object or array");
+    }
+
+    private String normalizeJson(Object parsedJson) throws JSONException {
+        if(parsedJson instanceof JSONObject || parsedJson instanceof JSONArray) {
+            return parsedJson.toString();
+        }
+        throw new JSONException("Offsets URL did not return a JSON object or array");
+    }
+
+    private String buildOffsetsChangelog(Object parsedJson) {
+        StringBuilder changelog = new StringBuilder(getString(R.string.mod_check_offsets_found));
+        if(!(parsedJson instanceof JSONObject)) {
+            return changelog.toString();
+        }
+
+        JSONObject offsetsInfo = (JSONObject) parsedJson;
+        String version = offsetsInfo.optString("version");
+        String contributors = formatContributors(offsetsInfo.opt("contributors"));
+        String comments = formatOffsetsComments(offsetsInfo);
+
+        if(hasText(version)) {
+            changelog.append("\n\n").append(getString(R.string.offsets_version, escapeMarkdown(version)));
+        }
+        if(hasText(contributors)) {
+            changelog.append("\n").append(getString(R.string.offsets_contributors, contributors));
+        }
+        if(hasText(comments)) {
+            changelog.append("\n\n").append(comments);
+        }
+        return changelog.toString();
+    }
+
+    private String formatContributors(Object contributors) {
+        if(contributors instanceof JSONArray) {
+            return formatContributorList((JSONArray) contributors);
+        }
+        if(contributors != null && contributors != JSONObject.NULL) {
+            return escapeMarkdown(String.valueOf(contributors));
+        }
+        return "";
+    }
+
+    private String formatContributorList(JSONArray contributors) {
+        if(contributors.length() == 0) return "";
+
+        StringBuilder builder = new StringBuilder();
+        for(int i = 0; i < contributors.length(); i++) {
+            String contributor = contributors.optString(i);
+            if(!hasText(contributor)) continue;
+            if(builder.length() > 0) builder.append(", ");
+            builder.append(escapeMarkdown(contributor));
+        }
+        return builder.toString();
+    }
+
+    private String formatOffsetsComments(JSONObject offsetsInfo) {
+        Object comments = offsetsInfo.opt("comments");
+        if(comments instanceof JSONArray) {
+            return formatCommentList((JSONArray) comments);
+        }
+        if(comments != null && comments != JSONObject.NULL) {
+            return escapeMarkdown(String.valueOf(comments));
+        }
+        return "";
+    }
+
+    private String formatCommentList(JSONArray comments) {
+        StringBuilder builder = new StringBuilder();
+        for(int i = 0; i < comments.length(); i++) {
+            String comment = comments.optString(i);
+            if(!hasText(comment)) continue;
+            if(builder.length() > 0) builder.append('\n');
+            builder.append("- ").append(escapeMarkdown(comment));
+        }
+        return builder.toString();
+    }
+
+    private String escapeMarkdown(String text) {
+        return text
+            .replace("\\", "\\\\")
+            .replace("*", "\\*")
+            .replace("_", "\\_")
+            .replace("`", "\\`")
+            .replace("[", "\\[")
+            .replace("]", "\\]")
+            .replace("#", "\\#");
+    }
+
+    private File getOffsetsFile() {
+        String modLibName = mLibraryPath.getName();
+        if(modLibName.endsWith(".so")) {
+            modLibName = modLibName.substring(0, modLibName.length() - 3);
+        }
+        File configDir = new File(getFilesDir(), "config");
+        if(!configDir.exists()) configDir.mkdirs();
+        return new File(configDir, modLibName + "_offsets.json");
     }
 }

--- a/app/src/main/res/drawable/ic_build.xml
+++ b/app/src/main/res/drawable/ic_build.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?colorOnSurface"
+        android:pathData="M22.61,18.99l-9.08,-9.08c0.93,-2.34 0.45,-5.1 -1.44,-6.99C10.08,0.91 7.14,0.52 4.74,1.74l4.17,4.17l-2.83,2.83L1.83,4.61c-1.2,2.4 -0.75,5.29 1.26,7.3c1.89,1.89 4.65,2.34 6.99,1.41l9.08,9.08c0.39,0.39 1.03,0.39 1.42,0l2.03,-2.03c0.39,-0.38 0.39,-1.0 0,-1.38z" />
+</vector>

--- a/app/src/main/res/layout/mod_list_element.xml
+++ b/app/src/main/res/layout/mod_list_element.xml
@@ -66,6 +66,16 @@
                         android:textStyle="bold"
                         tools:text="ModuleName" />
 
+                    <ImageView
+                        android:id="@+id/import_offsets"
+                        android:layout_width="18dp"
+                        android:layout_height="18dp"
+                        android:layout_marginEnd="10dp"
+                        android:clickable="true"
+                        android:contentDescription="@string/import_offsets"
+                        android:focusable="true"
+                        android:src="@drawable/ic_build" />
+
                     <com.google.android.material.switchmaterial.SwitchMaterial
                         android:id="@+id/module_indicator"
                         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/mod_manager.xml
+++ b/app/src/main/res/layout/mod_manager.xml
@@ -293,19 +293,6 @@
                             android:gravity="center" />
 
                         <Button
-                            android:id="@+id/mm_importOffsets"
-                            android:layout_width="0dp"
-                            android:layout_height="54dp"
-                            android:layout_weight="1"
-                            android:layout_marginStart="4dp"
-                            android:layout_marginEnd="8dp"
-                            android:background="@drawable/buttons"
-                            android:onClick="onImportOffsetsClick"
-                            android:text="@string/import_offsets"
-                            android:textSize="12sp"
-                            android:gravity="center" />
-
-                        <Button
                             android:id="@+id/mm_modInfo"
                             android:layout_width="54dp"
                             android:layout_height="54dp"

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -59,6 +59,9 @@
     <string name="mod_check_updates_installing">Установка обновления…</string>
     <string name="mod_check_updates_complete">Обновление завершено!</string>
     <string name="mod_check_updates_error">Произошла ошибка</string>
+    <string name="mod_check_offsets_found">### **Найдены новые оффсеты**</string>
+    <string name="offsets_version">**Версия:** %1$s</string>
+    <string name="offsets_contributors">**Автор:** %1$s</string>
     <string name="settings_title">НАСТРОЙКИ</string>
 
     <!-- about_dialog -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,9 @@
     <string name="mod_check_updates_installing">Installing update…</string>
     <string name="mod_check_updates_complete">Update complete!</string>
     <string name="mod_check_updates_error">An error has occurred</string>
+    <string name="mod_check_offsets_found">### **New offsets are available**</string>
+    <string name="offsets_version">**Version:** %1$s</string>
+    <string name="offsets_contributors">**Contributors:** %1$s</string>
     <string name="settings_title">SETTINGS</string>
 
     <!-- about_dialog -->
@@ -169,7 +172,7 @@
     <string name="onboarding_offsets_title">What are Offsets?</string>
     <string name="onboarding_offsets_body">Offsets are memory addresses used by mods to interact with the game. When the game updates, these addresses change.\n\nImporting updated offset files allows your mods to support newer game versions immediately without waiting for a mod update.</string>
     <string name="offsets_note">Not every mod supports this feature</string>
-    <string name="offsets_import_desc">Select a mod and pick an offset file</string>
+    <string name="offsets_import_desc">Pick an offset file for this mod</string>
     <string name="offsets_discord_desc">Get help finding offset files</string>
     <string name="onboarding_offsets_message">Offsets are memory addresses used by mods to interact with the game. When the game updates, these addresses change. Importing updated offset files allows your mods to support newer game versions immediately without waiting for a mod update.\n\n<b>NOTE: NOT EVERY MOD SUPPORTS THIS FEATURE.</b>\n\nIf you need help finding offset files, join our Discord server.</string>
     <string name="join_discord">Join Discord</string>


### PR DESCRIPTION
Changes:
- Moves Import Offsets from the main Mods screen into each mod card.
- Adds a small tool icon next to the mod enable switch.
- Clicking the icon opens the existing offsets dialog for that specific mod.
- Import no longer asks the user to select a mod again.
- Adds offsets update support through the existing Check For Updates button.

Mod developers can now add an optional raw offsets json URL to their mod metadata:
```json
"offsetsUrl": "https://raw.githubusercontent.com/user/repo/main/libExample_offsets.json"
```
```json
{
  "name": "libSPT.so",
  "author": "Hinnli",
  "description": "https://t.me/SkyProtocolTool\nTraffic Inspector & Protocol Tool",
  "majorVersion": 1,
  "minorVersion": 4,
  "patchVersion": 5,
  "displayName": "Sky Protocol Tool",
  "displaysUI": true,
  "selfManagedUI": true,
  "githubReleasesUrl": "https://api.github.com/repos/HinnliDev/SkyProtocolTool/releases/latest",
  "offsetsUrl": "https://raw.githubusercontent.com/HinnliDev/SkyProtocolTool/main/libSPT_offsets.json",
  "dependencies": []
}
```


If `offsetsUrl` is set, `Check For Updates` can fetch and install updated offsets from the raw JSON file, even without a GitHub release updater.
The URL should point to an offsets json file with optional display metadata, for example:
```jsonc
{
  // contributors and comments support both string and array values
  "version": "1.4.5",
  "contributors": [
    "Hinnli",
    "HinnliDev",
  ],
  "comments": [
    "Line 1",
    "Line 2",
    "Line 3",
  ],
  // offsets/signatures...
}
```

<img width="258" height="500" alt="demo" src="https://github.com/user-attachments/assets/7060ed99-d370-47ec-a579-8a96b9374bf4" />
<img width="252" height="500" alt="demo" src="https://github.com/user-attachments/assets/f9dfc203-ad01-4c96-b2af-60aea8d6f4e6" />
