### PR TITLE
Cipher.h: resolve artpatch via include path instead of a relative `../..` path

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(
 
 target_include_directories(
         ciphered PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/Utils
         ${CMAKE_CURRENT_SOURCE_DIR}/Utils/KittyMemory
         ${CMAKE_CURRENT_SOURCE_DIR}/Core/imgui
         ${CMAKE_CURRENT_SOURCE_DIR}/Core

--- a/app/src/main/cpp/Core/Cipher/Cipher.h
+++ b/app/src/main/cpp/Core/Cipher/Cipher.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <vector>
 #include <string>
-#include "../../Utils/artpatch/artpatch.h"
+#include "artpatch/artpatch.h"
 #include <functional>
 
 /**


### PR DESCRIPTION
Tiny cleanup: The artpatch include in Cipher.h hardcodes the folder layout with a relative `../../` path, making the Cipher headers awkward to move or vendor. This switches it to a normal include path lookup (matching KittyMemory/imgui). Doesn't touch runtime behavior. The final libciphered.so is byte-identical. It just lets consumers place/vendor the Cipher headers via `-I` instead of mirroring the exact directory tree.