### PR TITLE
Handle GitHub release API rate limits in mod updater

### DIFF
--- a/app/src/main/java/git/artdeell/skymodloader/updater/ModUpdaterService.java
+++ b/app/src/main/java/git/artdeell/skymodloader/updater/ModUpdaterService.java
@@ -24,6 +24,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import git.artdeell.skymodloader.R;
 import git.artdeell.skymodloader.elfmod.ElfModMetadata;
@@ -33,6 +35,8 @@ public class ModUpdaterService extends AbstractUpdaterService {
     private static final String GITHUB_USER_AGENT = "Canvas-ModUpdater/1.8.0";
     private static final String GITHUB_API_REPOS_PREFIX = "https://api.github.com/repos/";
     private static final String GITHUB_WEB_PREFIX = "https://github.com/";
+    private static final Pattern HREF_ATTRIBUTE_PATTERN = Pattern.compile(
+        "\\shref\\s*=\\s*([\"'])([^\"']*)\\1", Pattern.CASE_INSENSITIVE);
     public static final String EXTRA_UPDATE_URL = "update_url";
     public static final String EXTRA_OFFSETS_URL = "offsets_url";
     public static final String EXTRA_LIB_NAME = "lib_name";
@@ -283,34 +287,31 @@ public class ModUpdaterService extends AbstractUpdaterService {
             int anchorEnd = html.indexOf('>', anchorStart);
             if(anchorEnd < 0) break;
 
-            int doubleQuoteHref = html.indexOf("href=\"", anchorStart);
-            int singleQuoteHref = html.indexOf("href='", anchorStart);
-            int hrefStart = -1;
-            char quote = '"';
-            if(doubleQuoteHref >= 0 && doubleQuoteHref < anchorEnd) {
-                hrefStart = doubleQuoteHref + "href=\"".length();
-            } else if(singleQuoteHref >= 0 && singleQuoteHref < anchorEnd) {
-                hrefStart = singleQuoteHref + "href='".length();
-                quote = '\'';
-            }
-            if(hrefStart < 0) {
+            String anchor = html.substring(anchorStart, anchorEnd + 1);
+            Matcher hrefMatcher = HREF_ATTRIBUTE_PATTERN.matcher(anchor);
+            if(!hrefMatcher.find()) {
                 cursor = anchorEnd + 1;
                 continue;
             }
 
-            int hrefEnd = html.indexOf(quote, hrefStart);
-            if(hrefEnd < 0) break;
-            String path = html.substring(hrefStart, hrefEnd);
-            if(path.startsWith(marker) && !path.contains("/../") && !path.contains("\\")) {
-                String encodedName = path.substring(path.lastIndexOf('/') + 1);
-                if(!encodedName.isEmpty()) {
+            String path = hrefMatcher.group(2);
+            if(path.startsWith(marker)) {
+                String encodedName = path.substring(marker.length());
+                if(!encodedName.isEmpty() && !encodedName.contains("/")
+                    && !encodedName.contains("\\") && !encodedName.contains("?")
+                    && !encodedName.contains("#") && !encodedName.equals(".")
+                    && !encodedName.equals("..")) {
                     String assetName = URLDecoder.decode(encodedName, StandardCharsets.UTF_8.name());
-                    String downloadUrl = GITHUB_WEB_PREFIX + path;
-                    if(seenUrls.add(downloadUrl)) {
-                        JSONObject asset = new JSONObject();
-                        asset.put("name", assetName);
-                        asset.put("browser_download_url", downloadUrl);
-                        assets.put(asset);
+                    if(!assetName.isEmpty() && !assetName.contains("/")
+                        && !assetName.contains("\\") && !assetName.equals(".")
+                        && !assetName.equals("..")) {
+                        String downloadUrl = GITHUB_WEB_PREFIX + path;
+                        if(seenUrls.add(downloadUrl)) {
+                            JSONObject asset = new JSONObject();
+                            asset.put("name", assetName);
+                            asset.put("browser_download_url", downloadUrl);
+                            assets.put(asset);
+                        }
                     }
                 }
             }
@@ -342,7 +343,7 @@ public class ModUpdaterService extends AbstractUpdaterService {
         connection.setRequestProperty("User-Agent", GITHUB_USER_AGENT);
         try {
             int responseCode = connection.getResponseCode();
-            if(responseCode >= 300 && responseCode <= 308) {
+            if(isRedirectResponse(responseCode)) {
                 String location = connection.getHeaderField("Location");
                 if(location == null || location.isEmpty()) {
                     throw new IOException("GitHub latest release redirect has no Location header");
@@ -360,6 +361,11 @@ public class ModUpdaterService extends AbstractUpdaterService {
         } finally {
             connection.disconnect();
         }
+    }
+
+    private boolean isRedirectResponse(int responseCode) {
+        return responseCode == 301 || responseCode == 302 || responseCode == 303
+            || responseCode == 307 || responseCode == 308;
     }
 
     private String extractReleaseTagFromRedirectPath(String path, String repository)

--- a/app/src/main/java/git/artdeell/skymodloader/updater/ModUpdaterService.java
+++ b/app/src/main/java/git/artdeell/skymodloader/updater/ModUpdaterService.java
@@ -19,13 +19,19 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
 
 import git.artdeell.skymodloader.R;
 import git.artdeell.skymodloader.elfmod.ElfModMetadata;
 import git.artdeell.skymodloader.elfmod.ElfRefcountLoader;
 
 public class ModUpdaterService extends AbstractUpdaterService {
+    private static final String GITHUB_USER_AGENT = "Canvas-ModUpdater/1.8.0";
+    private static final String GITHUB_API_REPOS_PREFIX = "https://api.github.com/repos/";
+    private static final String GITHUB_WEB_PREFIX = "https://github.com/";
     public static final String EXTRA_UPDATE_URL = "update_url";
     public static final String EXTRA_OFFSETS_URL = "offsets_url";
     public static final String EXTRA_LIB_NAME = "lib_name";
@@ -200,13 +206,163 @@ public class ModUpdaterService extends AbstractUpdaterService {
     }
 
     private JSONObject readJsonObject(String url) throws IOException, JSONException {
-        return new JSONObject(readUrl(url));
+        try {
+            return new JSONObject(readUrl(url));
+        } catch(IOException error) {
+            String message = error.getMessage();
+            boolean rateLimited = url.startsWith(GITHUB_API_REPOS_PREFIX)
+                && message != null
+                && (message.contains("API rate limit exceeded")
+                    || message.contains("RateLimit-Remaining: 0"));
+            if(!rateLimited) throw error;
+
+            Log.w("ModUpdaterService", "GitHub API quota exhausted; using public release fallback");
+            return readLatestReleaseWithoutApi(url);
+        }
+    }
+
+    private JSONObject readLatestReleaseWithoutApi(String apiUrl) throws IOException, JSONException {
+        String repository = githubRepositoryFromApiUrl(apiUrl);
+        if(repository == null) {
+            throw new IOException("Unsupported GitHub release API URL");
+        }
+
+        String tag = readLatestReleaseTag(repository);
+        String expandedAssetsUrl = GITHUB_WEB_PREFIX + repository
+            + "/releases/expanded_assets/" + tag;
+        JSONArray assets = extractReleaseAssets(readUrl(expandedAssetsUrl), repository, tag);
+        if(assets.length() == 0) {
+            throw new IOException("GitHub latest release has no downloadable assets");
+        }
+
+        JSONObject release = new JSONObject();
+        release.put("tag_name", tag);
+        release.put("body", "");
+        release.put("assets", assets);
+        return release;
+    }
+
+    private JSONArray extractReleaseAssets(String html, String repository, String tag)
+        throws IOException, JSONException {
+        String marker = "/" + repository + "/releases/download/" + tag + "/";
+        Set<String> seenUrls = new HashSet<>();
+        JSONArray assets = new JSONArray();
+        int cursor = 0;
+
+        while(cursor < html.length()) {
+            int start = html.indexOf(marker, cursor);
+            if(start < 0) break;
+
+            int end = start;
+            while(end < html.length()) {
+                char character = html.charAt(end);
+                if(character == '"' || character == '\'' || character == '<'
+                    || Character.isWhitespace(character) || character == '?' || character == '&') {
+                    break;
+                }
+                end++;
+            }
+
+            String path = html.substring(start, end);
+            String encodedName = path.substring(path.lastIndexOf('/') + 1);
+            if(!encodedName.isEmpty() && !path.contains("..")) {
+                String assetName = URLDecoder.decode(encodedName, StandardCharsets.UTF_8.name());
+                String downloadUrl = GITHUB_WEB_PREFIX + path;
+                if(seenUrls.add(downloadUrl)) {
+                    JSONObject asset = new JSONObject();
+                    asset.put("name", assetName);
+                    asset.put("browser_download_url", downloadUrl);
+                    assets.put(asset);
+                }
+            }
+            cursor = end;
+        }
+
+        return assets;
+    }
+
+    private String githubRepositoryFromApiUrl(String apiUrl) {
+        String suffix = "/releases/latest";
+        if(!apiUrl.startsWith(GITHUB_API_REPOS_PREFIX) || !apiUrl.endsWith(suffix)) {
+            return null;
+        }
+
+        String repository = apiUrl.substring(
+            GITHUB_API_REPOS_PREFIX.length(), apiUrl.length() - suffix.length());
+        return repository.matches("[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+            ? repository
+            : null;
+    }
+
+    private String readLatestReleaseTag(String repository) throws IOException {
+        URL latestUrl = new URL(GITHUB_WEB_PREFIX + repository + "/releases/latest");
+        HttpURLConnection connection = (HttpURLConnection) latestUrl.openConnection();
+        connection.setConnectTimeout(10000);
+        connection.setReadTimeout(10000);
+        connection.setInstanceFollowRedirects(false);
+        connection.setRequestProperty("User-Agent", GITHUB_USER_AGENT);
+        try {
+            int responseCode = connection.getResponseCode();
+            if(responseCode >= 300 && responseCode <= 308) {
+                String location = connection.getHeaderField("Location");
+                if(location == null || location.isEmpty()) {
+                    throw new IOException("GitHub latest release redirect has no Location header");
+                }
+                URL redirectUrl = new URL(latestUrl, location);
+                if(!"https".equalsIgnoreCase(redirectUrl.getProtocol())
+                    || !"github.com".equalsIgnoreCase(redirectUrl.getHost())) {
+                    throw new IOException("GitHub latest release redirected to an unexpected host");
+                }
+                return extractLatestReleaseTag(redirectUrl.getPath(), repository);
+            }
+
+            InputStream inputStream = responseCode >= 200 && responseCode < 300
+                ? connection.getInputStream()
+                : connection.getErrorStream();
+            String response = readStream(inputStream);
+            if(responseCode < 200 || responseCode >= 300) {
+                throw new IOException("GitHub release fallback failed: HTTP " + responseCode);
+            }
+            return extractLatestReleaseTag(response, repository);
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private String extractLatestReleaseTag(String source, String repository) throws IOException {
+        String marker = "/" + repository + "/releases/tag/";
+        int start = source.indexOf(marker);
+        if(start < 0) {
+            throw new IOException("GitHub latest release tag was not found");
+        }
+        start += marker.length();
+
+        int end = start;
+        while(end < source.length()) {
+            char character = source.charAt(end);
+            if(!Character.isLetterOrDigit(character)
+                && character != '.' && character != '_' && character != '-') {
+                break;
+            }
+            end++;
+        }
+
+        String tag = source.substring(start, end);
+        if(tag.isEmpty() || !tag.matches("[A-Za-z0-9._-]+")) {
+            throw new IOException("GitHub latest release tag is invalid");
+        }
+        return tag;
     }
 
     private String readUrl(String url) throws IOException {
         HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
         connection.setConnectTimeout(10000);
         connection.setReadTimeout(10000);
+        connection.setRequestProperty("User-Agent", GITHUB_USER_AGENT);
+        if(url.startsWith("https://api.github.com/")) {
+            connection.setRequestProperty("Accept", "application/vnd.github+json");
+            connection.setRequestProperty("X-GitHub-Api-Version", "2022-11-28");
+        }
         try {
             int responseCode = connection.getResponseCode();
             InputStream inputStream = responseCode >= 200 && responseCode < 300
@@ -214,7 +370,22 @@ public class ModUpdaterService extends AbstractUpdaterService {
                 : connection.getErrorStream();
             String response = readStream(inputStream);
             if(responseCode < 200 || responseCode >= 300) {
-                throw new IOException("Request failed: HTTP " + responseCode);
+                String responsePreview = response.replace('\n', ' ').replace('\r', ' ').trim();
+                if(responsePreview.length() > 500) {
+                    responsePreview = responsePreview.substring(0, 500);
+                }
+                String rateLimitRemaining = connection.getHeaderField("X-RateLimit-Remaining");
+                String rateLimitReset = connection.getHeaderField("X-RateLimit-Reset");
+                String requestId = connection.getHeaderField("X-GitHub-Request-Id");
+                String contentType = connection.getHeaderField("Content-Type");
+                String errorMessage = "Request failed: HTTP " + responseCode
+                    + " | Content-Type: " + contentType
+                    + " | RateLimit-Remaining: " + rateLimitRemaining
+                    + " | RateLimit-Reset: " + rateLimitReset
+                    + " | GitHub-Request-Id: " + requestId
+                    + " | Body: " + responsePreview;
+                Log.e("ModUpdaterService", errorMessage);
+                throw new IOException(errorMessage);
             }
             return response;
         } finally {
@@ -224,6 +395,9 @@ public class ModUpdaterService extends AbstractUpdaterService {
 
     private void downloadToFile(String url, File target) throws IOException {
         HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        connection.setConnectTimeout(10000);
+        connection.setReadTimeout(60000);
+        connection.setRequestProperty("User-Agent", GITHUB_USER_AGENT);
         connection.connect();
         try (InputStream inputStream = connection.getInputStream();
              FileOutputStream outputStream = new FileOutputStream(target)) {

--- a/app/src/main/java/git/artdeell/skymodloader/updater/ModUpdaterService.java
+++ b/app/src/main/java/git/artdeell/skymodloader/updater/ModUpdaterService.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import git.artdeell.skymodloader.R;
@@ -44,6 +45,27 @@ public class ModUpdaterService extends AbstractUpdaterService {
     private boolean mOffsetsUpdateAvailable;
     private String mModDownloadURL;
     private String mPendingOffsetsJson;
+
+    private static final class HttpRequestException extends IOException {
+        private final int responseCode;
+        private final String rateLimitRemaining;
+        private final String responseBody;
+
+        private HttpRequestException(int responseCode, String rateLimitRemaining,
+                                     String responseBody, String message) {
+            super(message);
+            this.responseCode = responseCode;
+            this.rateLimitRemaining = rateLimitRemaining;
+            this.responseBody = responseBody == null ? "" : responseBody;
+        }
+
+        private boolean isGithubRateLimit() {
+            if(responseCode != 403) return false;
+            String normalizedBody = responseBody.toLowerCase(Locale.ROOT);
+            return "0".equals(rateLimitRemaining)
+                || normalizedBody.contains("rate limit");
+        }
+    }
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
@@ -208,16 +230,15 @@ public class ModUpdaterService extends AbstractUpdaterService {
     private JSONObject readJsonObject(String url) throws IOException, JSONException {
         try {
             return new JSONObject(readUrl(url));
-        } catch(IOException error) {
-            String message = error.getMessage();
-            boolean rateLimited = url.startsWith(GITHUB_API_REPOS_PREFIX)
-                && message != null
-                && (message.contains("API rate limit exceeded")
-                    || message.contains("RateLimit-Remaining: 0"));
-            if(!rateLimited) throw error;
+        } catch(HttpRequestException error) {
+            if(!url.startsWith(GITHUB_API_REPOS_PREFIX) || !error.isGithubRateLimit()) {
+                throw error;
+            }
 
             Log.w("ModUpdaterService", "GitHub API quota exhausted; using public release fallback");
             return readLatestReleaseWithoutApi(url);
+        } catch(IOException error) {
+            throw error;
         }
     }
 
@@ -250,32 +271,50 @@ public class ModUpdaterService extends AbstractUpdaterService {
         int cursor = 0;
 
         while(cursor < html.length()) {
-            int start = html.indexOf(marker, cursor);
-            if(start < 0) break;
-
-            int end = start;
-            while(end < html.length()) {
-                char character = html.charAt(end);
-                if(character == '"' || character == '\'' || character == '<'
-                    || Character.isWhitespace(character) || character == '?' || character == '&') {
-                    break;
-                }
-                end++;
+            int anchorStart = html.indexOf("<a", cursor);
+            if(anchorStart < 0) break;
+            if(anchorStart + 2 < html.length()
+                && !Character.isWhitespace(html.charAt(anchorStart + 2))
+                && html.charAt(anchorStart + 2) != '>') {
+                cursor = anchorStart + 2;
+                continue;
             }
 
-            String path = html.substring(start, end);
-            String encodedName = path.substring(path.lastIndexOf('/') + 1);
-            if(!encodedName.isEmpty() && !path.contains("..")) {
-                String assetName = URLDecoder.decode(encodedName, StandardCharsets.UTF_8.name());
-                String downloadUrl = GITHUB_WEB_PREFIX + path;
-                if(seenUrls.add(downloadUrl)) {
-                    JSONObject asset = new JSONObject();
-                    asset.put("name", assetName);
-                    asset.put("browser_download_url", downloadUrl);
-                    assets.put(asset);
+            int anchorEnd = html.indexOf('>', anchorStart);
+            if(anchorEnd < 0) break;
+
+            int doubleQuoteHref = html.indexOf("href=\"", anchorStart);
+            int singleQuoteHref = html.indexOf("href='", anchorStart);
+            int hrefStart = -1;
+            char quote = '"';
+            if(doubleQuoteHref >= 0 && doubleQuoteHref < anchorEnd) {
+                hrefStart = doubleQuoteHref + "href=\"".length();
+            } else if(singleQuoteHref >= 0 && singleQuoteHref < anchorEnd) {
+                hrefStart = singleQuoteHref + "href='".length();
+                quote = '\'';
+            }
+            if(hrefStart < 0) {
+                cursor = anchorEnd + 1;
+                continue;
+            }
+
+            int hrefEnd = html.indexOf(quote, hrefStart);
+            if(hrefEnd < 0) break;
+            String path = html.substring(hrefStart, hrefEnd);
+            if(path.startsWith(marker) && !path.contains("/../") && !path.contains("\\")) {
+                String encodedName = path.substring(path.lastIndexOf('/') + 1);
+                if(!encodedName.isEmpty()) {
+                    String assetName = URLDecoder.decode(encodedName, StandardCharsets.UTF_8.name());
+                    String downloadUrl = GITHUB_WEB_PREFIX + path;
+                    if(seenUrls.add(downloadUrl)) {
+                        JSONObject asset = new JSONObject();
+                        asset.put("name", assetName);
+                        asset.put("browser_download_url", downloadUrl);
+                        assets.put(asset);
+                    }
                 }
             }
-            cursor = end;
+            cursor = anchorEnd + 1;
         }
 
         return assets;
@@ -313,45 +352,49 @@ public class ModUpdaterService extends AbstractUpdaterService {
                     || !"github.com".equalsIgnoreCase(redirectUrl.getHost())) {
                     throw new IOException("GitHub latest release redirected to an unexpected host");
                 }
-                return extractLatestReleaseTag(redirectUrl.getPath(), repository);
+                return extractReleaseTagFromRedirectPath(redirectUrl.getPath(), repository);
             }
 
-            InputStream inputStream = responseCode >= 200 && responseCode < 300
-                ? connection.getInputStream()
-                : connection.getErrorStream();
-            String response = readStream(inputStream);
-            if(responseCode < 200 || responseCode >= 300) {
-                throw new IOException("GitHub release fallback failed: HTTP " + responseCode);
-            }
-            return extractLatestReleaseTag(response, repository);
+            throw new IOException("GitHub latest release did not return a redirect: HTTP "
+                + responseCode);
         } finally {
             connection.disconnect();
         }
     }
 
-    private String extractLatestReleaseTag(String source, String repository) throws IOException {
+    private String extractReleaseTagFromRedirectPath(String path, String repository)
+        throws IOException {
         String marker = "/" + repository + "/releases/tag/";
-        int start = source.indexOf(marker);
-        if(start < 0) {
-            throw new IOException("GitHub latest release tag was not found");
+        if(!path.startsWith(marker)) {
+            throw new IOException("GitHub latest release redirect path is unexpected");
         }
-        start += marker.length();
-
-        int end = start;
-        while(end < source.length()) {
-            char character = source.charAt(end);
-            if(!Character.isLetterOrDigit(character)
-                && character != '.' && character != '_' && character != '-') {
-                break;
-            }
-            end++;
-        }
-
-        String tag = source.substring(start, end);
-        if(tag.isEmpty() || !tag.matches("[A-Za-z0-9._-]+")) {
+        String tag = path.substring(marker.length());
+        if(!isValidReleaseTag(tag)) {
             throw new IOException("GitHub latest release tag is invalid");
         }
         return tag;
+    }
+
+    private boolean isValidReleaseTag(String tag) {
+        if(tag.isEmpty() || tag.endsWith("/") || tag.contains("..")) return false;
+        for(int i = 0; i < tag.length(); i++) {
+            char character = tag.charAt(i);
+            if(Character.isLetterOrDigit(character) || character == '.' || character == '_'
+                || character == '-' || character == '+' || character == '/') {
+                continue;
+            }
+            if(character == '%' && i + 2 < tag.length()
+                && isHexDigit(tag.charAt(i + 1)) && isHexDigit(tag.charAt(i + 2))) {
+                i += 2;
+                continue;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isHexDigit(char character) {
+        return Character.digit(character, 16) >= 0;
     }
 
     private String readUrl(String url) throws IOException {
@@ -385,7 +428,8 @@ public class ModUpdaterService extends AbstractUpdaterService {
                     + " | GitHub-Request-Id: " + requestId
                     + " | Body: " + responsePreview;
                 Log.e("ModUpdaterService", errorMessage);
-                throw new IOException(errorMessage);
+                throw new HttpRequestException(
+                    responseCode, rateLimitRemaining, response, errorMessage);
             }
             return response;
         } finally {


### PR DESCRIPTION
# Handle GitHub release API rate limits in mod updater

## Summary

- Add an explicit `User-Agent`, GitHub JSON `Accept`, API version, and bounded timeouts to mod release requests.
- Preserve the complete HTTP failure evidence needed to diagnose rate limits and proxy responses.
- Fall back from an exhausted anonymous GitHub API quota to the public `releases/latest` redirect and `expanded_assets` page, without embedding a token.
- Keep the fallback generic so any mod using a GitHub Releases API URL can use it.

## Motivation

Canvas users behind shared NAT/ISP addresses can exhaust GitHub's unauthenticated API quota even for public repositories. The previous updater reported only `HTTP 403`, which made a valid release look unavailable.

Observed response:

```text
HTTP 403
RateLimit-Remaining: 0
API rate limit exceeded for 104.28.163.98
```

## Behavior

Normal API responses continue through the existing JSON release path. When GitHub explicitly reports an exhausted API quota, the updater:

1. Requests `https://github.com/<owner>/<repo>/releases/latest`.
2. Validates the HTTPS GitHub redirect and extracts the release tag.
3. Reads `/releases/expanded_assets/<tag>` and reconstructs the release asset list.
4. Reuses the existing target-asset selection and download/install flow.

Malformed redirects, missing tags, missing assets, non-quota errors, non-redirect
3xx statuses, nested asset paths, and non-`href` markup fail closed.

## Validation

- Focused Canvas updater regression/contract tests: `4 passed`.
- Live public fallback probe: latest redirect `302`; expanded-assets response `200`
  with `Canvas.apk`, `libTSM v0.30.1.so`, `libcosmo.so` discovered (perhaps other libs are too).
- Device validation of the quota-triggered public redirect: Canvas reached
  `Tag: 0.30.1` and displayed `No updates available` after the fallback warning.
- Device comparison with Cloudflare WARP disabled and enabled: the previous build
  failed with HTTP 403 on the shared WARP IP, while the patched build completed the
  update check in both network modes. Checks for other installed mods remained usable.
