### PR TITLE
Fix input race causing tooltip flicker and unresponsive keyboard

### DIFF
--- a/app/src/main/cpp/Utils/imgui_androidbk/androidbk.cpp
+++ b/app/src/main/cpp/Utils/imgui_androidbk/androidbk.cpp
@@ -15,6 +15,10 @@
 #include <EGL/egl.h>
 #include <GLES3/gl3.h>
 #include <unistd.h>
+#include <atomic>
+#include <cfloat>
+#include <mutex>
+#include <vector>
 #include "Canvas/Canvas.h"
 #include "../../include/misc/visibility.h"
 
@@ -170,6 +174,301 @@ PRIVATE_API void initContext() {
 
 }
 
+// --- thread-safe input bridge ----------------------------------------------
+//
+// renderloop() owns the ImGui context on the "imgui dispatch thread", and a
+// context may not be used from multiple threads in parallel.  Every JNI entry
+// point below is called from the Android UI thread, so none of them may touch
+// the context.
+//
+// Note that swapping "io.MousePos = ..." for io.AddMousePosEvent() would NOT be
+// sufficient: AddXXXEvent() pushes onto g.InputEventsQueue (an ImVector) and
+// reads live g.IO state to filter duplicates, so it is equally unsafe from a
+// foreign thread.  Instead the UI thread appends to our own locked queue and
+// the render thread replays it into ImGui immediately before NewFrame().
+//
+// The UI thread still has to answer wantsMouse()/wantsKeyboard() synchronously
+// (onTouchEvent must decide there and then whether to forward the touch to the
+// game).  It does that against a snapshot of window rects published by the
+// render thread at the end of each frame, so the decision stays position-aware
+// - which is what the old UpdateHoveredWindowAndCaptureFlags() call was for -
+// without reading live context state.
+namespace CanvasInput {
+
+struct Event {
+    enum Kind { MousePos, MouseButton, Key, Char };
+    Kind     kind;
+    float    x = 0.0f, y = 0.0f;
+    int      code = 0;      // mouse button index, or Android keycode
+    bool     down = false;
+    unsigned codepoint = 0;
+};
+
+static std::mutex         s_queueMutex;
+static std::vector<Event> s_queue;
+static float              s_lastX = -FLT_MAX;   // guarded by s_queueMutex
+static float              s_lastY = -FLT_MAX;
+
+struct Snapshot {
+    std::vector<ImVec4> hoverRects;             // min.xy, max.zw - padding applied
+    bool wantCaptureMouse = false;
+    bool wantTextInput    = false;
+    bool mouseDown        = false;              // io.MouseDown[0]
+    bool mouseDownOwned   = false;              // io.MouseDownOwned[0]
+};
+static std::mutex s_snapMutex;
+static Snapshot   s_snapshot;
+
+// Raised from the UI thread when the user dismisses the IME behind ImGui's back
+// (BACK key, window focus loss).  Applied on the render thread inside the frame.
+static std::atomic<bool> s_clearTextFocus{false};
+
+// ---- UI thread -------------------------------------------------------------
+
+static void PushMousePos(float x, float y) {
+    std::lock_guard<std::mutex> lk(s_queueMutex);
+    Event e; e.kind = Event::MousePos; e.x = x; e.y = y;
+    s_queue.push_back(e);
+    s_lastX = x; s_lastY = y;
+}
+
+static void PushMouseButton(int button, bool down) {
+    std::lock_guard<std::mutex> lk(s_queueMutex);
+    Event e; e.kind = Event::MouseButton; e.code = button; e.down = down;
+    s_queue.push_back(e);
+
+    // On release, tell ImGui the pointer left the screen - nothing else does.
+    // Otherwise io.MousePos keeps the lift-off coordinates indefinitely, so
+    // ImGui goes on reporting whatever sat under the finger as hovered (tooltips
+    // that outlive the touch that raised them), and the first frame of the NEXT
+    // touch computes an io.MouseDelta spanning both touches.  NewFrame() zeroes
+    // MouseDelta when either position fails IsMousePosValid, which is what this
+    // makes true.
+    //
+    // This is a pointer-lifecycle correctness fix, NOT a guard for scroll.cpp's
+    // drag-to-scroll: do_scroll() only reaches SetScrollY when hovered && !held,
+    // and neither branch can satisfy that on the press frame.  Over empty window
+    // space ButtonBehavior has just taken ActiveId, so held is true; over a
+    // widget HoveredId != 0, so ButtonBehavior is never called at all and
+    // hovered stays false.  The cross-touch delta is unreachable either way.
+    //
+    // Known limit: if a lift and the next touch-down fall inside one frame, the
+    // invalidation and the new position are applied in the same UpdateInputEvents
+    // pass (position events do not break each other) and only the new position
+    // survives to the frame boundary, so the delta is not zeroed for that
+    // gesture.  Left as-is deliberately - splitting the drain across frames to
+    // cover it would buy nothing given the paragraph above.
+    if (!down && button == 0) {
+        Event inv; inv.kind = Event::MousePos; inv.x = -FLT_MAX; inv.y = -FLT_MAX;
+        s_queue.push_back(inv);
+        // s_lastX/s_lastY deliberately keep the real lift-off coordinates, so
+        // the wantsMouse() hit test still resolves this ACTION_UP correctly.
+    }
+}
+
+static void PushKey(int keycode, bool down) {
+    std::lock_guard<std::mutex> lk(s_queueMutex);
+    Event e; e.kind = Event::Key; e.code = keycode; e.down = down;
+    s_queue.push_back(e);
+}
+
+static void PushChar(unsigned codepoint) {
+    std::lock_guard<std::mutex> lk(s_queueMutex);
+    Event e; e.kind = Event::Char; e.codepoint = codepoint;
+    s_queue.push_back(e);
+}
+
+static bool WantsMouse() {
+    float x, y;
+    {
+        std::lock_guard<std::mutex> lk(s_queueMutex);
+        x = s_lastX; y = s_lastY;
+    }
+    std::lock_guard<std::mutex> lk(s_snapMutex);
+    // An in-progress drag keeps capture even once the finger leaves the window,
+    // matching io.WantCaptureMouse's behaviour with an active item.
+    if (s_snapshot.wantCaptureMouse)
+        return true;
+    // Click ownership: a drag that began outside ImGui belongs to the game for
+    // its whole duration, even if it passes over a window.  Without this the
+    // hit test below would hijack a camera drag mid-stroke - ImGui itself
+    // enforces this via io.MouseDownOwned in UpdateHoveredWindowAndCaptureFlags.
+    if (s_snapshot.mouseDown && !s_snapshot.mouseDownOwned)
+        return false;
+    for (const ImVec4 &r : s_snapshot.hoverRects)
+        if (x >= r.x && y >= r.y && x < r.z && y < r.w)
+            return true;
+    return false;
+}
+
+static bool WantsKeyboard() {
+    std::lock_guard<std::mutex> lk(s_snapMutex);
+    return s_snapshot.wantTextInput;
+}
+
+// The IME can be dismissed without ImGui ever hearing about it (BACK key,
+// app switch), which leaves the InputText active and io.WantTextInput stuck
+// true.  GameActivity's imguiKeybaordShowing latch then believes the keyboard
+// is up while it is not, and never re-shows it - tapping a text field moves the
+// caret but raises no keyboard.  Ending the ImGui editing session drops
+// WantTextInput, which lets that latch settle by itself on the next touch, the
+// same way the IME "done" action already behaves.
+static void RequestClearTextFocus() {
+    s_clearTextFocus.store(true, std::memory_order_relaxed);
+}
+
+// ---- render thread ---------------------------------------------------------
+
+// Call immediately before ImGui::NewFrame().
+static void Drain() {
+    std::vector<Event> local;
+    {
+        std::lock_guard<std::mutex> lk(s_queueMutex);
+        local.swap(s_queue);
+    }
+    // Deliberately NOT tagged via AddMouseSourceEvent(ImGuiMouseSource_TouchScreen),
+    // even though these events genuinely are touches.  That tag activates ImGui's
+    // trickling rule for touch presses ("#2702: TouchScreen have no initial
+    // hover"), which defers a button-down to the frame AFTER the pointer move.
+    // Canvas cannot absorb that delay: wantsKeyboard() is only ever polled from
+    // GameActivity.onTouchEvent, so a quick tap at 60 fps finishes before the
+    // deferred press is applied and the soft keyboard does not open until the
+    // next touch.  Note the tag is sticky state, so setting it for position
+    // events alone would still leak onto the following button event.
+    // The only thing given up is ImGui's 3 px (rather than 2 px) stationary
+    // threshold for ImGuiHoveredFlags_Stationary - which is what this backend
+    // had before, since it never set a mouse source at all.
+    ImGuiIO &io = ImGui::GetIO();
+    for (const Event &e : local) {
+        switch (e.kind) {
+        case Event::MousePos:
+            io.AddMousePosEvent(e.x, e.y);
+            break;
+        case Event::MouseButton:
+            io.AddMouseButtonEvent(e.code, e.down);
+            break;
+        case Event::Key:
+            io.AddKeyEvent(ImGui_ImplAndroid_KeyCodeToImGuiKey(e.code), e.down);
+            break;
+        case Event::Char:
+            io.AddInputCharacter(e.codepoint);
+            break;
+        }
+    }
+}
+
+// Call immediately after ImGui::NewFrame(), so ActiveId is only ever touched
+// inside frame scope.  ClearActiveID() deactivates the InputText without
+// reverting it - unlike feeding Escape, which sets revert_edit and would throw
+// away whatever the user had typed.
+static void ApplyPendingFocusClear() {
+    if (!s_clearTextFocus.exchange(false, std::memory_order_relaxed))
+        return;
+    // Only ever end a TEXT session.  ClearActiveID() clears whatever currently
+    // owns ActiveId - and additionally drops g.MovingWindow when the id is a
+    // window's MoveId - so an unconditional call would cancel a slider drag or
+    // a window move if the window happened to change focus mid-gesture.
+    ImGuiContext *g = ImGui::GetCurrentContext();
+    if (g != nullptr && g->ActiveId != 0 && g->ActiveId == g->InputTextState.ID)
+        ImGui::ClearActiveID();
+}
+
+// Call after ImGui::Render(), when the frame is closed and g.Windows is stable.
+// Mirrors FindHoveredWindow()'s filters so the UI-thread hit test agrees with
+// what ImGui itself would decide for the same position.
+static void PublishSnapshot() {
+    ImGuiContext *g = ImGui::GetCurrentContext();
+    if (g == nullptr)
+        return;
+
+    Snapshot snap;
+    snap.wantCaptureMouse = g->IO.WantCaptureMouse;
+    snap.mouseDown        = g->IO.MouseDown[0];
+    snap.mouseDownOwned   = g->IO.MouseDownOwned[0];
+
+    // io.WantTextInput is written by NewFrame() from g.WantTextInputNextFrame,
+    // which InputTextEx sets during the frame BODY - so by the time we get here
+    // io.WantTextInput still describes the previous frame, and publishing it
+    // alone would cost a second frame of latency on top of the snapshot's own.
+    // Since wantsKeyboard() is polled only from onTouchEvent, that lost frame
+    // shows up as a short tap failing to raise the soft keyboard.  Folding in
+    // the pending request recovers the frame the old synchronous
+    // UpdateHoveredWindowAndCaptureFlags() call used to catch.
+    snap.wantTextInput    = g->IO.WantTextInput || (g->WantTextInputNextFrame == 1);
+
+    const ImVec2 paddingRegular = g->Style.TouchExtraPadding;
+    const ImVec2 paddingResize  = g->IO.ConfigWindowsResizeFromEdges
+                                      ? g->WindowsHoverPadding : paddingRegular;
+    snap.hoverRects.reserve((std::size_t)g->Windows.Size);
+    for (int i = 0; i < g->Windows.Size; i++) {
+        ImGuiWindow *w = g->Windows[i];
+        if (w == nullptr || !w->Active || w->Hidden)
+            continue;
+        if (w->Flags & ImGuiWindowFlags_NoMouseInputs)
+            continue;
+        const ImVec2 pad = (w->Flags & (ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize))
+                               ? paddingRegular : paddingResize;
+        const ImRect &r = w->OuterRectClipped;
+        snap.hoverRects.push_back(ImVec4(r.Min.x - pad.x, r.Min.y - pad.y,
+                                         r.Max.x + pad.x, r.Max.y + pad.y));
+    }
+
+    std::lock_guard<std::mutex> lk(s_snapMutex);
+    s_snapshot = std::move(snap);
+}
+
+// Call when the render loop stops (surface torn down).  Drops any backlog that
+// would otherwise replay on resurface(), and leaves ImGui with the pointer
+// released.
+static void Reset() {
+    s_clearTextFocus.store(false, std::memory_order_relaxed);
+    {
+        std::lock_guard<std::mutex> lk(s_queueMutex);
+        s_queue.clear();
+        s_lastX = -FLT_MAX;
+        s_lastY = -FLT_MAX;
+    }
+    {
+        std::lock_guard<std::mutex> lk(s_snapMutex);
+        s_snapshot = Snapshot();
+    }
+
+    // Leave the context with nothing pending and nothing held.  Both matter,
+    // because the ImGuiContext outlives the surface (CreateContext runs once;
+    // resurface() reuses it):
+    //
+    //  - ClearEventsQueue(): ImGui's OWN queue is not necessarily empty.
+    //    UpdateInputEvents processes events until a trickling rule breaks, then
+    //    keeps the remainder "for the next frame".  If the loop exits there, a
+    //    trailing button-down replays on resurface and latches a press at a
+    //    stale position with no finger on the screen.
+    //  - ClearInputKeys(): releases mouse buttons (plus MouseDown/Duration),
+    //    keyboard keys and the character queue.  Dropping our own queue above
+    //    can discard a pending ACTION_UP - or the up half of a key pair, since
+    //    ImGUITextInput.submitBackspace sends down and up separately.
+    //
+    // A latched io.MouseDown[0] would otherwise make the first published
+    // snapshot claim every touch after resurface - or, if the press was not
+    // ImGui's, refuse all of them - and AddMouseButtonEvent's duplicate filter
+    // would additionally swallow the next real press, since latest_button_down
+    // would already match.
+    //
+    // Written directly rather than queued: no further frame will run to drain a
+    // queue, and the render thread owns the context at this point.  ActiveId is
+    // deliberately NOT cleared - with the pointer released and MousePos
+    // invalid, any mouse-driven ActiveId self-releases on the first frame after
+    // resurface without firing, whereas an explicit ClearActiveID() would run
+    // InputTextDeactivateHook and discard an in-progress text edit.
+    if (ImGuiContext *g = ImGui::GetCurrentContext()) {
+        g->IO.ClearEventsQueue();
+        g->IO.ClearInputKeys();
+        // Not covered by ClearInputKeys(), which sets MousePos but not Prev.
+        g->IO.MousePosPrev = ImVec2(-FLT_MAX, -FLT_MAX);
+    }
+}
+
+} // namespace CanvasInput
+
 PRIVATE_API void newframe() {
     ImGuiIO& io = ImGui::GetIO();
     io.DisplaySize = ImVec2((float)ANativeWindow_getWidth(androidWindow), (float)ANativeWindow_getHeight(androidWindow));
@@ -187,15 +486,19 @@ PRIVATE_API void renderloop()
         if(Canvas::frameRateLimited) usleep(41000);
         ImGui_ImplOpenGL3_NewFrame();
         newframe();
+        CanvasInput::Drain();          // replay UI-thread input into ImGui
         ImGui::NewFrame();
+        CanvasInput::ApplyPendingFocusClear();
         Canvas::CanvasMenu();
         ImGui::Render();
+        CanvasInput::PublishSnapshot(); // serves next frame's UI-thread queries
         glViewport(0, 0, (int)io.DisplaySize.x, (int)io.DisplaySize.y);
         glClearColor(0, 0, 0, 0);
         glClear(GL_COLOR_BUFFER_BIT);
         ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
         eglSwapBuffers(g_EglDisplay, g_EglSurface);
     }
+    CanvasInput::Reset();
     eglMakeCurrent(g_EglDisplay, nullptr, nullptr, nullptr);
     eglDestroySurface(g_EglDisplay, g_EglSurface);
     g_EglSurface = nullptr;
@@ -343,39 +646,49 @@ Java_git_artdeell_skymodloader_ImGUI_shutdown(JNIEnv *env, jclass clazz) {
 extern "C"
 JNIEXPORT void JNICALL
 Java_git_artdeell_skymodloader_ImGUI_submitPositionEvent(JNIEnv *env, jclass clazz, jfloat x, jfloat y) {
-    ImGuiIO &io = ImGui::GetIO();
-    io.MousePos = ImVec2(x,y);
+    CanvasInput::PushMousePos(x, y);
 }
 extern "C"
 JNIEXPORT void JNICALL
 Java_git_artdeell_skymodloader_ImGUI_submitButtonEvent(JNIEnv *env, jclass clazz, jint btn,
                                                        jboolean pressed) {
-    ImGuiIO &io = ImGui::GetIO();
-    io.AddMouseButtonEvent(btn, pressed);
+    CanvasInput::PushMouseButton(btn, pressed);
 }
 extern "C"
 JNIEXPORT jboolean JNICALL
 Java_git_artdeell_skymodloader_ImGUI_wantsKeyboard(JNIEnv *env, jclass clazz) {
-    ImGui::UpdateHoveredWindowAndCaptureFlags();
-    return ImGui::GetIO().WantTextInput;
+    // Previously called ImGui::UpdateHoveredWindowAndCaptureFlags() here, which
+    // mutates g.HoveredWindow from the UI thread mid-frame.  Served from the
+    // render thread's published snapshot now.
+    return CanvasInput::WantsKeyboard();
 }
 extern "C"
 JNIEXPORT void JNICALL
 Java_git_artdeell_skymodloader_ImGUI_submitUnicodeEvent(JNIEnv *env, jclass clazz,
                                                         jchar codepoint) {
-    ImGui::GetIO().AddInputCharacter(codepoint);
+    CanvasInput::PushChar((unsigned)codepoint);
+}
+extern "C"
+JNIEXPORT void JNICALL
+Java_git_artdeell_skymodloader_ImGUI_clearTextFocus(JNIEnv *env, jclass clazz) {
+    CanvasInput::RequestClearTextFocus();
 }
 extern "C"
 JNIEXPORT void JNICALL
 Java_git_artdeell_skymodloader_ImGUI_submitKeyEvent(JNIEnv *env, jclass clazz, jint key,
                                                     jboolean down) {
-    ImGui::GetIO().AddKeyEvent(ImGui_ImplAndroid_KeyCodeToImGuiKey(key), down);
+    // Called from ImGUITextInput on the UI thread; the keycode is mapped on the
+    // render thread inside Drain() so nothing touches the context here.
+    CanvasInput::PushKey(key, down);
 }
 extern "C"
 JNIEXPORT jboolean JNICALL
 Java_git_artdeell_skymodloader_ImGUI_wantsMouse(JNIEnv *env, jclass clazz) {
-    ImGuiIO &io = ImGui::GetIO();
-    return io.WantCaptureMouse;
+    // Position-aware hit test against the render thread's published rects, so a
+    // touch landing on a window is still claimed on its very first event (what
+    // the old mid-frame UpdateHoveredWindowAndCaptureFlags() call achieved),
+    // without reading live context state.
+    return CanvasInput::WantsMouse();
 }
 extern "C"
 JNIEXPORT void JNICALL

--- a/app/src/main/java/git/artdeell/skymodloader/ImGUI.java
+++ b/app/src/main/java/git/artdeell/skymodloader/ImGUI.java
@@ -47,6 +47,8 @@ public class ImGUI implements SurfaceHolder.Callback{
     public static native void submitButtonEvent(int btn, boolean pressed);
     public static native void submitUnicodeEvent(char codepoint);
     public static native void submitKeyEvent(int key, boolean down);
+    /** End the active ImGui text-editing session, keeping whatever was typed. */
+    public static native void clearTextFocus();
     public static native boolean wantsKeyboard();
     public static native boolean wantsMouse();
 

--- a/app/src/main/java/git/artdeell/skymodloader/ImGUITextInput.java
+++ b/app/src/main/java/git/artdeell/skymodloader/ImGUITextInput.java
@@ -273,6 +273,20 @@ public class ImGUITextInput extends androidx.appcompat.widget.AppCompatEditText 
         setVisibility(GONE);
         clearFocus();
         setEnabled(false);
+        // End the ImGui editing session in lockstep.  Hiding this view alone
+        // leaves the InputText active and io.WantTextInput stuck true, which
+        // desynchronises GameActivity's imguiKeybaordShowing latch: it believes
+        // the keyboard is already up and never re-shows it, so tapping a text
+        // field afterwards only moves the caret.
+        // Placed here rather than at the individual dismissal sites so the view
+        // state and the ImGui session cannot diverge - every route that hides
+        // the IME (BACK key, window focus change, IME "done" on a multiline
+        // field, GameActivity lowering the keyboard) passes through here.
+        // Safe to call unconditionally: the native side only acts when the
+        // ImGui item being edited is the one holding ActiveId, so this is a
+        // no-op when ImGui has already deactivated the field or is busy with
+        // some other widget.
+        ImGUI.clearTextFocus();
     }
 
     /** Send the enter key. */


### PR DESCRIPTION
Two bugs, one cause.

1. **Tooltips flickered** every few seconds while a finger was held still, most obvious with Limit FPS on.
2. **Tapping a text field sometimes only moved the caret** without opening the keyboard, until you tapped somewhere else first.

Both came down to Canvas touching ImGui from two threads at once, the render thread and the Android UI thread. Input from the UI thread is now buffered and replayed on the render thread, so ImGui state is only ever written from one place.

Verified against libSPT, libTSM and libtibik on a Galaxy A52 and a OnePlus 13: tooltips stable, keyboard reliable, scrolling smooth, existing mod behaviour unchanged.

Happy to expand on any of it.

## Before / after

**Tooltip flicker**

_Before:_ 

https://github.com/user-attachments/assets/3e0dcbe8-4bd4-4b86-a642-232951d770e7

_After:_ 

https://github.com/user-attachments/assets/4d4aec4e-0b21-4f13-8917-49bc7eeaa934

**Keyboard not opening**

_Before:_ 

https://github.com/user-attachments/assets/1660ebaa-c080-4628-8869-38ca2ccbf737

_After:_ 

https://github.com/user-attachments/assets/fb7fd65f-7648-428b-9732-8d4a4dc272ce
