### PR TITLE
Recover from decoder failures, and let mods actually see the player

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:name=".SMLApplication"
         android:process="com.tgc.sky.android.sml"
         android:allowBackup="true"
+        android:appCategory="game"
         android:allowNativeHeapPointerTagging="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:localeConfig="@xml/locales_config"

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -433,10 +433,9 @@ Java_git_artdeell_skymodloader_MainActivity_nativeSetStarwatchAllowed(
 // A key prefixed `is_` is a boolean: 1 or 0, never any other value.
 // Read those through the typed wrappers rather than as raw numbers, and
 // do not introduce an unprefixed boolean key alongside them.
-// Absence is stored as NaN, never as a magic number: the query cannot know a
-// key's legal range, so a negative sentinel would swallow any future signed
-// value. The query reports absence as false and leaves the caller's out
-// parameter untouched, rather than handing back something it might render.
+// A key with no value right now reports false and leaves the caller's out
+// parameter untouched - never a sentinel a caller might render.  See kAbsent
+// below for how absence is stored.
 namespace {
     // NaN, not a negative number, means "no value right now".  The query cannot
     // know a given key's legal range, so a negative sentinel would silently

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -9,6 +9,10 @@
 #include "Core/imgui/imgui.h"
 #include "Utils/imgui_androidbk/androidbk.h"
 #include "include/misc/Vector3.h"
+#include <atomic>
+#include <cmath>
+#include <cstring>
+#include <limits>
 #include <vector>
 #include "Canvas/Canvas.h"
 #include "Cipher/CipherUtils.h"
@@ -382,4 +386,118 @@ Java_git_artdeell_skymodloader_MainActivity_nativeSetStarwatchAllowed(
         jboolean allowed
 ) {
     starwatch_block_set_allowed(allowed == JNI_TRUE);
+}
+
+// ---------------------------------------------------------------------------
+// Host value channel for user libs.
+//
+// One weak-linked entry point instead of one exported symbol per capability:
+// a mod gates on this ONCE and every future key costs a string rather than an
+// ABI addition and a Canvas release cycle.
+//
+// extern "C" on purpose.  A C++ static would tie both sides to an exact mangled
+// name, and any signature drift would make the mod's weak symbol resolve null -
+// which is indistinguishable from "this Canvas is too old", permanently.
+//
+// CONTRACT (mods rely on all three):
+//   - callable from ANY thread, including a mod's ImGui thread
+//   - never blocks: no JNI, no I/O, no lock.  Values are snapshots Canvas
+//     already sampled on the thread that owns them.  ExoPlayer in particular
+//     must only be touched on its application looper, so the video keys are
+//     pushed down from UpdateMediaPlayer rather than pulled on demand.
+//   - cheap enough to call per frame
+//
+// KEY REGISTRY - this comment is the source of truth, and the table in
+// CanvasQueryHostNumber must match it exactly:
+//
+//   video.duration_ms    total length of the playing video.
+//                        Absent for live streams, before the player reaches
+//                        STATE_READY, and for containers that carry no
+//                        duration at all (MPEG-TS).  "absent" therefore does
+//                        NOT imply live - query video.is_live for that.
+//   video.position_ms    current playback position.  For live content this is
+//                        relative to the start of the live window, which moves.
+//   video.is_live        1 / 0.  From Player.isCurrentMediaItemLive().
+//   video.is_seekable    1 / 0.  From Player.isCurrentMediaItemSeekable().
+//                        Having a duration does NOT imply being seekable.
+//   video.is_buffering   1 while the player is stalled fetching data, else 0.
+//                        Distinct from is_ended and from position simply not
+//                        advancing, so a mod can show a spinner without guessing.
+//   video.is_ended       1 when the player has reached the end of the video,
+//                        else 0.  A looping mod should watch this rather than
+//                        compare position against duration, which need not land
+//                        exactly on it.  Kept a boolean, not the raw
+//                        Player.STATE_* enum, so the channel does not marry a
+//                        backend's state numbering.
+//
+// A key prefixed `is_` is a boolean: 1 or 0, never any other value.
+// Read those through the typed wrappers rather than as raw numbers, and
+// do not introduce an unprefixed boolean key alongside them.
+// Absence is stored as NaN, never as a magic number: the query cannot know a
+// key's legal range, so a negative sentinel would swallow any future signed
+// value. The query reports absence as false and leaves the caller's out
+// parameter untouched, rather than handing back something it might render.
+namespace {
+    // NaN, not a negative number, means "no value right now".  The query cannot
+    // know a given key's legal range, so a negative sentinel would silently
+    // swallow any future signed value - an audio balance, a live-edge offset -
+    // at exactly the values it most needed to report, and would do it quietly:
+    // the caller just sees "unavailable", which is a legal answer.  Deciding
+    // absence belongs to each push site, which does know the range.
+    constexpr double kAbsent = std::numeric_limits<double>::quiet_NaN();
+    std::atomic<double> g_videoDurationMs{kAbsent};
+    std::atomic<double> g_videoPositionMs{kAbsent};
+    std::atomic<double> g_videoIsLive{kAbsent};
+    std::atomic<double> g_videoIsSeekable{kAbsent};
+    std::atomic<double> g_videoIsBuffering{kAbsent};
+    std::atomic<double> g_videoIsEnded{kAbsent};
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_git_artdeell_skymodloader_MainActivity_nativeSetVideoStats(
+        JNIEnv *env,
+        jclass clazz,
+        jlong durationMs,
+        jlong positionMs,
+        jint isLive,
+        jint isSeekable,
+        jint playbackState
+) {
+    // Java signals absence with -1 for all of these, none of which can
+    // legitimately be negative.  Translate here, at the push site, so the stored
+    // form stays range-agnostic.
+    const auto put = [](std::atomic<double> &cell, long long v) {
+        cell.store(v < 0 ? kAbsent : static_cast<double>(v),
+                   std::memory_order_relaxed);
+    };
+    put(g_videoDurationMs, durationMs);
+    put(g_videoPositionMs, positionMs);
+    put(g_videoIsLive, isLive);
+    put(g_videoIsSeekable, isSeekable);
+    // Player.STATE_BUFFERING == 2, STATE_ENDED == 4.  A negative state means no
+    // player, which stays absent; otherwise each collapses to its one bit.
+    put(g_videoIsBuffering, playbackState < 0 ? -1 : (playbackState == 2));
+    put(g_videoIsEnded, playbackState < 0 ? -1 : (playbackState == 4));
+}
+
+extern "C"
+bool CanvasQueryHostNumber(const char *_key, double *_out) {
+    if (_key == nullptr || _out == nullptr) return false;
+    const struct { const char *key; std::atomic<double> *cell; } table[] = {
+        {"video.duration_ms", &g_videoDurationMs},
+        {"video.position_ms", &g_videoPositionMs},
+        {"video.is_live",     &g_videoIsLive},
+        {"video.is_seekable", &g_videoIsSeekable},
+        {"video.is_buffering", &g_videoIsBuffering},
+        {"video.is_ended",    &g_videoIsEnded},
+    };
+    for (const auto &e : table) {
+        if (std::strcmp(_key, e.key) != 0) continue;
+        const double v = e.cell->load(std::memory_order_relaxed);
+        if (std::isnan(v)) return false;  // known key, no value right now
+        *_out = v;
+        return true;
+    }
+    return false;                    // unknown key: this Canvas is older
 }

--- a/app/src/main/java/com/tgc/sky/ExoplayerService.java
+++ b/app/src/main/java/com/tgc/sky/ExoplayerService.java
@@ -236,18 +236,18 @@ class ExoplayerService {
         return this.m_player.isCurrentMediaItemLive() ? 1 : 0;
     }
 
-    // Player.STATE_* (1 idle, 2 buffering, 3 ready, 4 ended), or -1 with no
-    // player. m_state is written by VideoListener.onPlaybackStateChanged.
-    public int GetPlaybackState() {
-        return this.m_player == null ? -1 : this.m_state;
-    }
-
     public int GetSeekableState() {
         if (this.m_player == null
                 || !this.m_player.isCommandAvailable(Player.COMMAND_GET_CURRENT_MEDIA_ITEM)) {
             return -1;
         }
         return this.m_player.isCurrentMediaItemSeekable() ? 1 : 0;
+    }
+
+    // Player.STATE_* (1 idle, 2 buffering, 3 ready, 4 ended), or -1 with no
+    // player. m_state is written by VideoListener.onPlaybackStateChanged.
+    public int GetPlaybackState() {
+        return this.m_player == null ? -1 : this.m_state;
     }
     // ---- end Canvas addition -------------------------------------------
 

--- a/app/src/main/java/com/tgc/sky/ExoplayerService.java
+++ b/app/src/main/java/com/tgc/sky/ExoplayerService.java
@@ -8,16 +8,23 @@ import android.media.Image;
 import android.media.ImageReader;
 import android.os.Build;
 import android.util.Log;
+import androidx.media3.common.C;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.Player;
 import androidx.media3.datasource.DefaultDataSource;
 import androidx.media3.exoplayer.DefaultLoadControl;
+import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.hls.HlsMediaSource;
+import androidx.media3.exoplayer.mediacodec.MediaCodecInfo;
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector;
+import androidx.media3.exoplayer.mediacodec.MediaCodecUtil;
 import androidx.media3.exoplayer.trackselection.AdaptiveTrackSelection;
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector;
 import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @SuppressLint("UnsafeOptInUsageError")
@@ -29,6 +36,13 @@ class ExoplayerService {
     Image m_image1;
     ImageReader m_imageReader;
     ExoPlayer m_player;
+    // Decoders that have already failed on this device. VideoListener adds to
+    // it on a decoder error; the MediaCodecSelector below filters against it so
+    // the retry picks a different decoder. Matches TGC 0.34.5.
+    List<String> codecBlackList = new ArrayList<>();
+    // Written by VideoListener.onPlaybackStateChanged. TGC stores it but never
+    // reads it; kept for parity.
+    int m_state;
 
     public void Initialize(Context context) {
         if (this.m_player == null) {
@@ -37,9 +51,29 @@ class ExoplayerService {
             DefaultBandwidthMeter build = new DefaultBandwidthMeter.Builder(context).build();
             DefaultTrackSelector defaultTrackSelector = new DefaultTrackSelector(context, new AdaptiveTrackSelection.Factory());
             this.m_hlsMediaFactory = new HlsMediaSource.Factory(new DefaultDataSource.Factory(context));
-            ExoPlayer build2 = new ExoPlayer.Builder(context).setBandwidthMeter(build).setTrackSelector(defaultTrackSelector).setLoadControl(defaultLoadControl).build();
+            DefaultRenderersFactory defaultRenderersFactory = new DefaultRenderersFactory(context);
+            defaultRenderersFactory.setMediaCodecSelector(new MediaCodecSelector() {
+                @Override
+                public List<MediaCodecInfo> getDecoderInfos(String str, boolean z, boolean z2)
+                        throws MediaCodecUtil.DecoderQueryException {
+                    List<MediaCodecInfo> decoderInfos = MediaCodecUtil.getDecoderInfos(str, z, z2);
+                    List<MediaCodecInfo> allowed = new ArrayList<>();
+                    for (MediaCodecInfo mediaCodecInfo : decoderInfos) {
+                        if (!ExoplayerService.this.codecBlackList.contains(mediaCodecInfo.name)) {
+                            allowed.add(mediaCodecInfo);
+                        }
+                    }
+                    // If every decoder is blacklisted, fall back to the last one
+                    // rather than returning an empty list and failing outright.
+                    if (allowed.isEmpty() && !decoderInfos.isEmpty()) {
+                        allowed.add(decoderInfos.get(decoderInfos.size() - 1));
+                    }
+                    return allowed;
+                }
+            });
+            ExoPlayer build2 = new ExoPlayer.Builder(context).setRenderersFactory(defaultRenderersFactory).setBandwidthMeter(build).setTrackSelector(defaultTrackSelector).setLoadControl(defaultLoadControl).build();
             this.m_player = build2;
-            build2.addListener(new VideoListener());
+            build2.addListener(new VideoListener(this));
         }
     }
 
@@ -167,6 +201,55 @@ class ExoplayerService {
             this.m_player.pause();
         }
     }
+
+    // ---- Canvas addition, NOT part of TGC parity ----------------------
+    // Sky exposes seek but never a duration, so a mod can jump to a timestamp
+    // yet cannot draw a timeline. These feed the host value channel.
+    // All guarded by COMMAND_GET_CURRENT_MEDIA_ITEM, which is what the Media3
+    // javadoc requires for every one of them.
+    public long GetDurationMs() {
+        if (this.m_player == null
+                || !this.m_player.isCommandAvailable(Player.COMMAND_GET_CURRENT_MEDIA_ITEM)) {
+            return -1L;
+        }
+        long duration = this.m_player.getDuration();
+        // Live streams and duration-less containers report TIME_UNSET.
+        return duration == C.TIME_UNSET ? -1L : duration;
+    }
+
+    public long GetPositionMs() {
+        if (this.m_player == null
+                || !this.m_player.isCommandAvailable(Player.COMMAND_GET_CURRENT_MEDIA_ITEM)) {
+            return -1L;
+        }
+        return this.m_player.getCurrentPosition();
+    }
+
+    // -1 unknown, 0 no, 1 yes. Deliberately separate from GetDurationMs:
+    // "no duration" does not imply live, and having a duration does not imply
+    // being seekable.
+    public int GetLiveState() {
+        if (this.m_player == null
+                || !this.m_player.isCommandAvailable(Player.COMMAND_GET_CURRENT_MEDIA_ITEM)) {
+            return -1;
+        }
+        return this.m_player.isCurrentMediaItemLive() ? 1 : 0;
+    }
+
+    // Player.STATE_* (1 idle, 2 buffering, 3 ready, 4 ended), or -1 with no
+    // player. m_state is written by VideoListener.onPlaybackStateChanged.
+    public int GetPlaybackState() {
+        return this.m_player == null ? -1 : this.m_state;
+    }
+
+    public int GetSeekableState() {
+        if (this.m_player == null
+                || !this.m_player.isCommandAvailable(Player.COMMAND_GET_CURRENT_MEDIA_ITEM)) {
+            return -1;
+        }
+        return this.m_player.isCurrentMediaItemSeekable() ? 1 : 0;
+    }
+    // ---- end Canvas addition -------------------------------------------
 
     public void Seek(long j) {
         if (this.m_player.isCommandAvailable(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)) {

--- a/app/src/main/java/com/tgc/sky/SystemIO_android.java
+++ b/app/src/main/java/com/tgc/sky/SystemIO_android.java
@@ -1135,6 +1135,16 @@ public class SystemIO_android {
                 if (GetMetadata != null) {
                     SystemIO_android.this.ReceiveVideoMetadataNative(GetMetadata.width, GetMetadata.height, GetMetadata.framesPerSecond);
                 }
+                // Canvas addition: publish video stats for user libs. This runnable
+                // already runs per frame on the ExoPlayer application looper, which
+                // is the only thread allowed to touch the player - hence pushing
+                // the values down rather than letting mods pull them.
+                git.artdeell.skymodloader.MainActivity.nativeSetVideoStats(
+                        SystemIO_android.this.mExoplayer.GetDurationMs(),
+                        SystemIO_android.this.mExoplayer.GetPositionMs(),
+                        SystemIO_android.this.mExoplayer.GetLiveState(),
+                        SystemIO_android.this.mExoplayer.GetSeekableState(),
+                        SystemIO_android.this.mExoplayer.GetPlaybackState());
                 double GetPlaybackPositionMs = SystemIO_android.this.mExoplayer.GetPlaybackPositionMs() / 1000.0d;
                 HardwareBuffer GetNextHardwareBuffer = SystemIO_android.this.mExoplayer.GetNextHardwareBuffer();
                 if (GetNextHardwareBuffer != null) {
@@ -1153,6 +1163,12 @@ public class SystemIO_android {
         this.mSubtitleRequest = null;
     }
 
+
+    // Canvas addition: reset the published stats so a finished video does not
+    // leave a stale duration visible to mods.
+    static void clearVideoStats() {
+        git.artdeell.skymodloader.MainActivity.nativeSetVideoStats(-1L, -1L, -1, -1, -1);
+    }
 
     void PauseMediaPlayer() {
         this.m_activity.runOnUiThread(new Runnable() {
@@ -1186,6 +1202,7 @@ public class SystemIO_android {
             @Override
             public void run() {
                 SystemIO_android.this.mExoplayer.EndVideo();
+                clearVideoStats(); // Canvas addition
             }
         });
     }

--- a/app/src/main/java/com/tgc/sky/VideoListener.java
+++ b/app/src/main/java/com/tgc/sky/VideoListener.java
@@ -1,14 +1,41 @@
 package com.tgc.sky;
 
+import android.annotation.SuppressLint;
 import android.util.Log;
 import androidx.media3.common.PlaybackException;
 import androidx.media3.common.Player;
 import androidx.media3.datasource.HttpDataSource;
+import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.mediacodec.MediaCodecDecoderException;
+import androidx.media3.exoplayer.mediacodec.MediaCodecInfo;
+import androidx.media3.exoplayer.mediacodec.MediaCodecRenderer;
 
+@SuppressLint("UnsafeOptInUsageError")
 class VideoListener implements Player.Listener {
     public String TAG = "VideoListener";
+    public ExoPlayer m_player;
+    public int m_retryTime;
+    public ExoplayerService m_service;
 
-    VideoListener() {
+    public VideoListener(ExoplayerService exoplayerService) {
+        this.m_retryTime = 0;
+        this.m_service = exoplayerService;
+        // Safe: Initialize() assigns m_player before constructing this.
+        this.m_player = exoplayerService.m_player;
+    }
+
+    @Override
+    public void onPlaybackStateChanged(int i) {
+        this.m_service.m_state = i;
+    }
+
+    @Override
+    public void onIsPlayingChanged(boolean z) {
+        // A successful play means the previous failure is behind us, so the
+        // three-attempt budget starts over.
+        if (z) {
+            this.m_retryTime = 0;
+        }
     }
 
     @Override
@@ -18,7 +45,46 @@ class VideoListener implements Player.Listener {
         if (cause instanceof HttpDataSource.HttpDataSourceException) {
             HttpDataSource.HttpDataSourceException httpDataSourceException = (HttpDataSource.HttpDataSourceException) cause;
             Throwable cause2 = httpDataSourceException.getCause();
+            if (cause2 != null) {
+                Log.d(this.TAG, "Video HTTP Error: " + cause2.toString() + ":" + cause2.getMessage());
+            }
             boolean z = httpDataSourceException instanceof HttpDataSource.InvalidResponseCodeException;
+        }
+
+        boolean wasPlaying = this.m_player.isPlaying() || this.m_player.getPlayWhenReady();
+
+        // The decoder exceptions are the CAUSE of the PlaybackException, not the
+        // exception itself.
+        MediaCodecInfo mediaCodecInfo = null;
+        if (cause instanceof MediaCodecRenderer.DecoderInitializationException) {
+            mediaCodecInfo = ((MediaCodecRenderer.DecoderInitializationException) cause).codecInfo;
+        } else if (cause instanceof MediaCodecDecoderException) {
+            mediaCodecInfo = ((MediaCodecDecoderException) cause).codecInfo;
+        }
+        if (mediaCodecInfo != null && !this.m_service.codecBlackList.contains(mediaCodecInfo.name)) {
+            Log.d(this.TAG, "Add Decoder to blackList. " + mediaCodecInfo.name);
+            this.m_service.codecBlackList.add(mediaCodecInfo.name);
+            this.m_service.EndVideo();
+        }
+
+        if (wasPlaying && this.m_retryTime < 3) {
+            Log.d(this.TAG, "Retry to play the Video. " + this.m_retryTime + "/3");
+            this.m_retryTime++;
+            if (this.m_player.isCommandAvailable(Player.COMMAND_STOP)) {
+                this.m_player.stop();
+            }
+            if (this.m_player.isCommandAvailable(Player.COMMAND_SET_VIDEO_SURFACE)) {
+                this.m_player.clearVideoSurface();
+                if (this.m_service.m_imageReader != null) {
+                    this.m_player.setVideoSurface(this.m_service.m_imageReader.getSurface());
+                }
+            }
+            if (this.m_player.isCommandAvailable(Player.COMMAND_PREPARE)) {
+                this.m_player.prepare();
+            }
+            if (this.m_player.isCommandAvailable(Player.COMMAND_PLAY_PAUSE)) {
+                this.m_player.play();
+            }
         }
     }
 }

--- a/app/src/main/java/git/artdeell/skymodloader/MainActivity.java
+++ b/app/src/main/java/git/artdeell/skymodloader/MainActivity.java
@@ -534,6 +534,15 @@ public class MainActivity extends Activity {
     private static native void nativeSetSkyBuildKey(String key);
     private static native void nativeSetStarwatchAllowed(boolean allowed);
 
+    // Video stats pushed down from SystemIO_android.UpdateMediaPlayer, which
+    // already runs per frame on the thread that owns the ExoPlayer instance.
+    // Mods read these through CanvasQueryHostNumber; see the key registry in
+    // main.cpp. Pass -1 for a value that is not available - none of these can
+    // legitimately be negative, and the native side translates it.
+    public static native void nativeSetVideoStats(long durationMs, long positionMs,
+                                                  int isLive, int isSeekable,
+                                                  int playbackState);
+
     public static class DeviceInfo {
         public float xdpi;
         public float ydpi;


### PR DESCRIPTION
## What this unlocks

Today a user lib can start a video and stop it. That is the entire vocabulary.
It cannot tell how long the video is, how far into it you are, whether it is a live stream, or whether it is still buffering.

So nobody can build a seek bar. Not because seeking is missing - the engine has always had it - but because a mod has no idea where it currently is or how far it is allowed to go. It is a steering wheel with the windscreen painted over.

This opens the windscreen.

<!-- VIDEO: scrubbing proof -->
https://github.com/user-attachments/assets/1722d9be-885f-448d-80c8-942acf5141d2

## Why this belongs in Canvas and not in a mod

The player lives here. It also insists on being touched from exactly one thread, and a mod is native code that has no business reaching across into Java to go looking for it.

So these values have to be read on this side, where that is safe, and handed over. There is no version of this that lives in a mod.

## One door, instead of a hallway of doors

The obvious way to expose this is a method per thing:

```
CanvasGetVideoDuration()
CanvasGetVideoPosition()
CanvasIsVideoLive()
CanvasIsVideoSeekable()
CanvasIsVideoBuffering()
CanvasIsVideoEnded()
```

Six values means six exported symbols, each one ABI this project carries forever and its own "does this Canvas have it yet" check on the mod side. Then someone wants playback speed and it is seven. Then a track title, and it is eight. Each perfectly reasonable alone, and collectively a hallway of single-purpose doors that can never be closed again.

`CanvasQueryHostNumber` is one door. Mods ask for a value by name, so the next one costs a name rather than a symbol. Older builds simply answer "I do not have that", and the mod hides the feature instead of breaking.

It is deliberately `CanvasQueryHostNUMBER` and not `CanvasQueryHostVALUE`. A number can be handed instantly and safely from any thread. Text cannot: it needs a buffer to copy into and a lock to copy under, and folding that in would put the cost on every numeric read forever. So if text is ever wanted it belongs in a separate `CanvasQueryHostString`, and the narrower name is what keeps that door open.

For the same reason, absence is signalled with NaN rather than a magic number like -1. A sentinel would quietly fence off part of the range for every key that ever exists: an audio balance, a live-edge offset, a pitch shift in semitones are all legitimately negative, and all would read as "no value" at exactly the readings that matter. NaN is not a number any key would want to return, so nothing is off-limits.

## For mod authors

The whole of the mod side:

```c
// weak, so an older Canvas resolves this to null instead of failing to load
extern "C" bool CanvasQueryHostNumber(const char *key, double *out) __attribute__((weak));

double ms;
if (CanvasQueryHostNumber && CanvasQueryHostNumber("video.duration_ms", &ms)) {
    // draw the seek bar
} else {
    // older Canvas, or nothing playing - hide it
}
```

Both failure modes land in the same branch, so there is no version check to get wrong.

Keys currently answered:

| key | meaning |
| --- | --- |
| `video.duration_ms` | total length; absent for live streams |
| `video.position_ms` | how far in |
| `video.is_live` | 1 or 0 |
| `video.is_seekable` | 1 or 0 |
| `video.is_buffering` | 1 or 0 |
| `video.is_ended` | 1 or 0 |

## Also in here

**Decoder recovery, restored.** TGC's own player retries a failed video a few times, and blacklists a decoder that keeps failing so it can fall back to a different one. Canvas lost that at some point, so one failing decoder or a brief network hiccup killed playback permanently. This puts it back, matching TGC's behaviour.

**The app declares itself a game.** Sky does. Canvas did not. One line.

## Testing

The host values are confirmed on a device - the video above is a mod reading them and driving a real seek bar.

The decoder recovery is verified against TGC's shipped code, but not exercised at runtime: it only fires on an actual decoder or network failure, which is hard to stage on purpose.
